### PR TITLE
[Order] 도메인 및 TDD 기반 개발 구조 정리

### DIFF
--- a/src/main/java/com/conk/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/conk/order/command/domain/aggregate/Order.java
@@ -1,0 +1,94 @@
+package com.conk.order.command.domain.aggregate;
+
+import java.time.LocalDate;
+
+public class Order {
+
+  /*
+   * - 주문번호
+   *   주문을 식별하는 핵심 값이므로 null 또는 blank 를 허용하지 않는다.
+   * */
+  private final String orderNo;
+
+  /*
+   * - 주문일자
+   *   통계나 조회 기준이 되는 값이므로 null을 허용하지 않는다.
+   * */
+  private final LocalDate orderDate;
+
+  /*
+   * - 주문 일자
+   *   생성 이후 cancel(), markOutboundCompleted() 같은 도메인 행위에 의해 바뀐다.
+   * */
+  private OrderStatus status;
+
+  /*
+   * 외부에서 직접 생성자를 호출하지 못하게 막고,
+   * create() 팩토리 메서드를 통해 생성 규칙을 강제한다.
+   * */
+  private Order(String orderNo, LocalDate orderDate, OrderStatus status) {
+    validateOrderNo(orderNo);
+    validateOrderDate(orderDate);
+    this.orderNo = orderNo;
+    this.orderDate = orderDate;
+    this.status = status;
+
+  }
+
+  /*
+   * - 주문 생성 팩토리 메서드
+   *   새 주문은 하상 출고 대기 상태로 시작한다는 규칙을 표현한다.
+   * */
+  public boolean isPendingOutbound() {
+    return status == OrderStatus.PENDING_OUTBOUND;
+  }
+
+  /*
+   * 주문을 출고 완료 상태로 변경한다.
+   *
+   * 단, 이미 취소된 주문은 출고 완료 처리할 수 없다.
+   * 이 규칙을 어기면 예외를 발생시킨다.
+   * */
+  public void markOutboundCompleted() {
+    if (status == OrderStatus.CANCELED) {
+      throw new IllegalStateException("Canceled order cannot be completed.");
+    }
+    this.status = OrderStatus.OUTBOUND_COMPLETED;
+  }
+
+  /*
+   * 주문을 취소 상태로 변경한다.
+   *
+   * 현재는 단순히 상태만 바꾸지만,
+   * 이후 정책에 따라 "이미 출고 완료된 주문은 취소 불가" 같은 규칙을 추가할 수 있다.
+   * */
+  public void cancel() {
+    this.status = OrderStatus.CANCELED;
+  }
+
+  /*
+   * 테스트 검증용 getter.
+   * 현재 단계에서는 도메인 상태를확인하기 위해 최소한으로 열어둔다.
+   * */
+  public String getOrderNo() {
+    return orderNo;
+  }
+
+  public LocalDate getOrderDate() {
+    return orderDate;
+  }
+
+  public OrderStatus getStatus() {
+    return status;
+  }
+
+  /*
+   * 주문 번호 필수 값 검증
+   * */
+  private void validateOrderNo(String orderNo) {
+    if (orderNo == null || orderNo.isBlank()) {
+      throw new IllegalArgumentException("Order number is required.");
+    }
+  }
+
+}

--- a/src/main/java/com/conk/order/command/domain/aggregate/OrderStatus.java
+++ b/src/main/java/com/conk/order/command/domain/aggregate/OrderStatus.java
@@ -1,0 +1,8 @@
+package com.conk.order.command.domain.aggregate;
+
+public enum OrderStatus {
+  PENDING_OUTBOUND,
+  OUTBOUND_COMPLETED,
+  CANCELED
+
+}

--- a/src/test/java/com/conk/order/command/domain/aggregate/OrderTest.java
+++ b/src/test/java/com/conk/order/command/domain/aggregate/OrderTest.java
@@ -1,0 +1,43 @@
+package com.conk.order.command.domain.aggregate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import java.time.LocalDate;
+
+
+public class OrderTest {
+
+  @Test
+  void createCreatesPendingOutboundOrder() {
+    Order order = Order.create("ORD-20260327-001", LocalDate.of (2026, 3, 27));
+
+    assertThat(order.getOrderNo()).isEqualTo("ORD-20260327-001");
+    assertThat(order.getOrderDate()).isEqualTo(Locaate.of(2026, 3, 27));
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.PENDING_OUTBOUND);
+  }
+
+  @Test
+  void isPendingOutboundReturnsTrueOnlyForPendingStatus() {
+    Order order = Order.create("ORD-20260327-001", LocalDate.of(2026, 3, 27));
+
+    assertThat(order.isPendingOutbound()).isTrue();
+
+    order.markOutboundCompleted();
+
+    assertThat(order.isPendingOutbound()).isFalse();
+  }
+
+
+  @Test
+  void canceledOrderCannotBeMarkedAsOutboundCompleted() {
+    Order order = Order.create("ORD-20260327-001", LocalDate.of(2026, 3, 27));
+    order.cancel();
+
+    assertThatThrownBy(order::markOutboundCompleted())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Canceled order cannot be completed.");
+  }
+
+}


### PR DESCRIPTION
## 📝 변경 사항
  - Order 백엔드의 TDD 진행을 위한 기본 문서와 개발 규칙을 정리했습니다.
  - Order 도메인 테스트 기반 개발을 시작할 수 있도록 초기 구조를 준비했습니다.
  - `.gitignore`에 현재 버전 관리하지 않을 문서/설정 경로를 추가했습니다.

  ## 🔍 주요 작업 내용
  - [x] Backend: `AGENTS.md`, `docs/order-development-plan.md`,
  `docs/order-dev-log.md`, `docs/troubleshooting.md`, `docs/
  TDD.md` 기반 개발 문서 정리
  - [x] Backend: Order 도메인 테스트 초안 작성 시작
  - [x] Backend: 프로젝트 개발 흐름을 TDD 기준으로 정리
  - [ ] Frontend: 없음
  - [ ] DB: 없음

  ## 📸 스크린샷 (선택)
  - 없음

  ## 💬 리뷰어에게 한마디
  - 이번 PR은 기능 완료 PR이 아니라 Order 백엔드 개발을 시작하기 위한 문서/구조 정리 성격입니다.
  - 이후 `Order`, `OrderItem`, `ShippingAddress` 등 핵심 도메인 테스트를 먼저 고정한 뒤 기능 구현으로 넘어갈 예정입니다.