### PR TITLE
[Order] 주문 도메인 규칙 테스트 및 상태 정책 추가

### DIFF
--- a/src/main/java/com/conk/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/conk/order/command/domain/aggregate/Order.java
@@ -18,7 +18,7 @@ public class Order {
 
   /*
    * - 주문 상태
-   *   생성 이후 cancel(), markOutboundCompleted() 같은 도메인 행위에 의해 바뀐다.
+   *   생성 이후 cancelOrder(), markOutboundCompleted() 같은 도메인 행위에 의해 바뀐다.
    * */
   private OrderStatus status;
 
@@ -36,19 +36,19 @@ public class Order {
 
   /**
    * - 주문 생성
-   * 새 주문은 기본적으로 PENDING_OUTBOUND 상태로 시작한다.
+   *   새 주문은 항상 출고 대기 상태로 시작한다는 규칙을 표현한다.
    *
    * @param orderNo   주문번호
    * @param orderDate 주문일자
-   * @return
+   * @return Order
    */
   public static Order create(String orderNo, LocalDate orderDate) {
     return new Order(orderNo, orderDate, OrderStatus.PENDING_OUTBOUND);
   }
 
   /*
-   * - 주문 생성 팩토리 메서드
-   *   새 주문은 하상 출고 대기 상태로 시작한다는 규칙을 표현한다.
+   * 출고 대기 여부를 반환한다.
+   * 출고 처리나 통계 집계 시 대상 주문을 필터링하는 데 사용된다.
    * */
   public boolean isPendingOutbound() {
     return status == OrderStatus.PENDING_OUTBOUND;
@@ -69,35 +69,28 @@ public class Order {
 
   /*
    * 주문을 취소 상태로 변경한다.
-   *
-   * 현재는 단순히 상태만 바꾸지만,
-   * 이후 정책에 따라 "이미 출고 완료된 주문은 취소 불가" 같은 규칙을 추가할 수 있다.
+   * 단, 이미 출고 완료된 주문은 취소할 수 없다.
    * */
-  public void cancel() {
+  public void cancelOrder() {
+    if (status == OrderStatus.OUTBOUND_COMPLETED) {
+      throw new IllegalStateException("Completed order cannot be canceled.");
+    }
     this.status = OrderStatus.CANCELED;
   }
 
   /*
    * 테스트 검증용 getter.
-   * 현재 단계에서는 도메인 상태를확인하기 위해 최소한으로 열어둔다.
+   * 현재 단계에서는 도메인 상태를 확인하기 위해 최소한으로 열어둔다.
    * */
-  public String getOrderNo() {
-    return orderNo;
-  }
-
-  public LocalDate getOrderDate() {
-    return orderDate;
-  }
-
-  public OrderStatus getStatus() {
-    return status;
-  }
+  public String getOrderNo() { return orderNo; }
+  public LocalDate getOrderDate() { return orderDate; }
+  public OrderStatus getStatus() { return status; }
 
   /**
    * - 주문번호
    * 주문 번호 필수 값 검증
    *
-   * @param orderNo
+   * @param orderNo 주문번호
    */
   private void validateOrderNo(String orderNo) {
     if (orderNo == null || orderNo.isBlank()) {
@@ -113,7 +106,9 @@ public class Order {
    */
   private void validateOrderDate(LocalDate orderDate) {
     if (orderDate == null) {
-      throw new IllegalArgumentException("Order date is required");
+      throw new IllegalArgumentException("Order date is required.");
     }
   }
+
+
 }

--- a/src/test/java/com/conk/order/command/domain/aggregate/OrderTest.java
+++ b/src/test/java/com/conk/order/command/domain/aggregate/OrderTest.java
@@ -11,7 +11,7 @@ public class OrderTest {
 
   @Test
   void createCreatesPendingOutboundOrder() {
-    Order order = Order.create("ORD-20260327-001", LocalDate.of (2026, 3, 27));
+    Order order = Order.create("ORD-20260327-001", LocalDate.of(2026, 3, 27));
 
     assertThat(order.getOrderNo()).isEqualTo("ORD-20260327-001");
     assertThat(order.getOrderDate()).isEqualTo(LocalDate.of(2026, 3, 27));
@@ -33,11 +33,35 @@ public class OrderTest {
   @Test
   void canceledOrderCannotBeMarkedAsOutboundCompleted() {
     Order order = Order.create("ORD-20260327-001", LocalDate.of(2026, 3, 27));
-    order.cancel();
+    order.cancelOrder();
 
     assertThatThrownBy(order::markOutboundCompleted)
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Canceled order cannot be completed.");
   }
+  @Test
+  void createFailsWhenOrderNoIsBlank() {
+    assertThatThrownBy(() -> Order.create(" ", LocalDate.of(2026, 3, 27)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Order number is required.");
+  }
 
+  @Test
+  void createFailsWhenOrderDateIsNull() {
+    assertThatThrownBy(() -> Order.create("ORD-20260327-001", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Order date is required.");
+  }
+
+  @Test
+  void completedOrderCannotBeCanceled() {
+    Order order = Order.create("ORD-20260327-001", LocalDate.of(2026, 3, 27));
+    order.markOutboundCompleted();
+
+    assertThatThrownBy(order::cancelOrder)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Completed order cannot be canceled.");
+  }
 }
+
+


### PR DESCRIPTION
검증과 출고 완료 후 취소 불가 정책을 추가했습니다.

  ## 🔍 주요 작업 내용
  - [x] Backend: `OrderStatus` enum 추가
  - [x] Backend: `Order` 도메인 객체에 생성, 출고 완료, 주문 취소, 필수값
  검증 로직 추가
  - [x] Backend: `OrderTest`에 생성/상태 전이/예외 테스트 추가
  - [ ] Frontend: 없음
  - [ ] DB: 없음

  ## 📸 스크린샷 (선택)
  - 없음

  ## 💬 리뷰어에게 한마디
  - 현재 단계는 API 구현 전 도메인 규칙을 먼저 고정하는 작업입니다.
  - 이후 `OrderItem`, `ShippingAddress` 등 도메인을 확장한 뒤 서비스/컨트롤러 구현으로 넘어갈 예정입니다.