### PR TITLE
feat: 주문 aggregate 도메인 구성

### DIFF
--- a/src/main/java/com/conk/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/conk/order/command/domain/aggregate/Order.java
@@ -1,49 +1,65 @@
 package com.conk.order.command.domain.aggregate;
 
-import java.time.LocalDate;
+import jakarta.persistence.Entity;
+import lombok.Getter;
 
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
 public class Order {
 
-  /*
-   * - 주문번호
-   *   주문을 식별하는 핵심 값이므로 null 또는 blank 를 허용하지 않는다.
-   * */
   private final String orderNo;
-
-  /*
-   * - 주문일자
-   *   통계나 조회 기준이 되는 값이므로 null을 허용하지 않는다.
-   * */
   private final LocalDate orderDate;
-
-  /*
-   * - 주문 상태
-   *   생성 이후 cancelOrder(), markOutboundCompleted() 같은 도메인 행위에 의해 바뀐다.
-   * */
   private OrderStatus status;
+  private final List<OrderItem> items;
+  private final ShippingAddress shippingAddress;
 
   /*
    * 외부에서 직접 생성자를 호출하지 못하게 막고,
    * create() 팩토리 메서드를 통해 생성 규칙을 강제한다.
    * */
-  private Order(String orderNo, LocalDate orderDate, OrderStatus status) {
+  private Order(
+      String orderNo,
+      LocalDate orderDate,
+      List<OrderItem> items,
+      ShippingAddress shippingAddress,
+      OrderStatus status
+  ) {
     validateOrderNo(orderNo);
     validateOrderDate(orderDate);
+    validateItems(items);
+    validateShippingAddress(shippingAddress);
     this.orderNo = orderNo;
     this.orderDate = orderDate;
+    this.items = items;
+    this.shippingAddress = shippingAddress;
     this.status = status;
   }
 
   /**
-   * - 주문 생성
-   *   새 주문은 항상 출고 대기 상태로 시작한다는 규칙을 표현한다.
+   *  - 주문 생성
+   *    새 주문은 항상 출고 대기 상태로 시작한다는 규칙을 표현한다.
    *
-   * @param orderNo   주문번호
-   * @param orderDate 주문일자
+   * @param orderNo 주문번호
+   * @param orderDate 주문날짜
+   * @param items 주문 항목 목록
+   * @param shippingAddress 배송지
+   *
    * @return Order
    */
-  public static Order create(String orderNo, LocalDate orderDate) {
-    return new Order(orderNo, orderDate, OrderStatus.PENDING_OUTBOUND);
+  public static Order create(
+      String orderNo,
+      LocalDate orderDate,
+      List<OrderItem> items,
+      ShippingAddress shippingAddress
+  ) {
+    return new Order(
+        orderNo,
+        orderDate,
+        items,
+        shippingAddress,
+        OrderStatus.PENDING_OUTBOUND);
   }
 
   /*
@@ -78,14 +94,6 @@ public class Order {
     this.status = OrderStatus.CANCELED;
   }
 
-  /*
-   * 테스트 검증용 getter.
-   * 현재 단계에서는 도메인 상태를 확인하기 위해 최소한으로 열어둔다.
-   * */
-  public String getOrderNo() { return orderNo; }
-  public LocalDate getOrderDate() { return orderDate; }
-  public OrderStatus getStatus() { return status; }
-
   /**
    * - 주문번호
    * 주문 번호 필수 값 검증
@@ -110,5 +118,15 @@ public class Order {
     }
   }
 
+  private void validateItems(List<OrderItem> items) {
+    if (items == null || items.isEmpty()) {
+      throw new IllegalArgumentException("Order items are required.");
+    }
+  }
 
+  private void validateShippingAddress(ShippingAddress shippingAddress) {
+    if (shippingAddress == null) {
+      throw new IllegalArgumentException("Shipping address is required.");
+    }
+  }
 }

--- a/src/main/java/com/conk/order/command/domain/aggregate/OrderItem.java
+++ b/src/main/java/com/conk/order/command/domain/aggregate/OrderItem.java
@@ -1,0 +1,38 @@
+package com.conk.order.command.domain.aggregate;
+
+import lombok.Getter;
+
+/*
+ * - 주문 항목 도메인 객체.
+ *
+ *   한 주문 안에 포함되는 개별 상품 단위를 표현한다.
+ * 현재 단계에서는 SKU와 수량만 최소 필드로 둔다.
+ *   */
+@Getter
+public class OrderItem {
+  private final String sku;
+  private final int quantity;
+
+  private OrderItem(String sku, int quantity) {
+    validateSku(sku);
+    validateQuantity(quantity);
+    this.sku = sku;
+    this.quantity = quantity;
+  }
+
+  public static OrderItem create(String sku, int quantity) {
+    return new OrderItem(sku, quantity);
+  }
+
+  private void validateSku(String sku) {
+    if (sku == null || sku.isBlank()) {
+      throw new IllegalArgumentException("SKU is required.");
+    }
+  }
+
+  private void validateQuantity(int quantity) {
+    if (quantity < 1) {
+      throw new IllegalArgumentException("Quantity must be greater than zero.");
+    }
+  }
+}

--- a/src/main/java/com/conk/order/command/domain/aggregate/ShippingAddress.java
+++ b/src/main/java/com/conk/order/command/domain/aggregate/ShippingAddress.java
@@ -1,0 +1,52 @@
+package com.conk.order.command.domain.aggregate;
+
+import lombok.Getter;
+
+/*
+ * - 배송지 값 객체
+ *
+ *   주문 배송에 필요한 주소 정보를 표현한다.
+ *   현재 단계에서는 필수 주소 정보 최소한으로 검증한다.
+ * */
+@Getter
+public class ShippingAddress {
+
+  private final String address1;
+  private final String address2;
+  private final String city;
+  private final String state;
+  private final String zipCode;
+
+  private ShippingAddress(String address1, String address2, String city, String state, String zipCode) {
+    validateAddress1(address1);
+    validateCity(city);
+    validateZipCode(zipCode);
+    this.address1 = address1;
+    this.address2 = address2;
+    this.city = city;
+    this.state = state;
+    this.zipCode = zipCode;
+  }
+
+  public static ShippingAddress create(String address1, String address2, String city, String state, String zipCode) {
+    return new ShippingAddress(address1,address2, city, state, zipCode);
+  }
+
+  private void validateAddress1(String address1) {
+    if (address1 == null || address1.isBlank()) {
+      throw new IllegalArgumentException("Address1 is required.");
+    }
+  }
+
+  private void validateCity(String city) {
+    if (city == null || city.isBlank()) {
+      throw new IllegalArgumentException("City is required.");
+    }
+  }
+
+  private void validateZipCode(String zipCode) {
+    if (zipCode == null || zipCode.isBlank()) {
+      throw new IllegalArgumentException("Zip code is required.");
+    }
+  }
+}

--- a/src/test/java/com/conk/order/command/domain/aggregate/OrderItemTest.java
+++ b/src/test/java/com/conk/order/command/domain/aggregate/OrderItemTest.java
@@ -1,0 +1,40 @@
+package com.conk.order.command.domain.aggregate;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/*
+ * OrderItem 도메인 규칙 테스트
+ * 주문 항목은 SKU와 수량을 최소 필수값으로 가지며,
+ * 잘못된 값으로 생성되지 않도록 검증한다.
+ * */
+public class OrderItemTest {
+
+  /* 정상 SKU와 수량으로 주문 항목이 생성되는지 확인한다. */
+  @Test
+  void createCreatesOrderItemWithValidSkuAndQuantity() {
+    OrderItem orderItem = OrderItem.create("SKU-001", 3);
+
+    assertThat(orderItem.getSku()).isEqualTo("SKU-001");
+    assertThat(orderItem.getQuantity()).isEqualTo(3);
+
+  }
+
+  /* SKU가 비어 있으면 생성할 수 없는지 확인한다. */
+  @Test
+  void createFailsWhenSkuIsBlank() {
+    assertThatThrownBy(() -> OrderItem.create(" ", 3))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("SKU is required.");
+  }
+
+  /* 수량이 1 미만이면 생성할 수 없는지 확인한다. */
+  @Test
+  void createFailsWhenQuantityIsLessThanOne() {
+    assertThatThrownBy(() -> OrderItem.create("SKU-001", 0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Quantity must be greater than zero.");
+  }
+}

--- a/src/test/java/com/conk/order/command/domain/aggregate/OrderTest.java
+++ b/src/test/java/com/conk/order/command/domain/aggregate/OrderTest.java
@@ -3,24 +3,31 @@ package com.conk.order.command.domain.aggregate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
+import java.util.List;
 
+import org.junit.jupiter.api.Test;
 
+/*
+ * Order 도메인 규칙 테스트.
+ * 주문 aggregate 생성 규칙과 상태 전이 규칙을 검증한다.
+ * */
 public class OrderTest {
 
+  /* 정상 주문 생성 시 기본 상태가 출고 대기인지 확인한다. */
   @Test
   void createCreatesPendingOutboundOrder() {
-    Order order = Order.create("ORD-20260327-001", LocalDate.of(2026, 3, 27));
+    Order order = createValidOrder();
 
     assertThat(order.getOrderNo()).isEqualTo("ORD-20260327-001");
     assertThat(order.getOrderDate()).isEqualTo(LocalDate.of(2026, 3, 27));
     assertThat(order.getStatus()).isEqualTo(OrderStatus.PENDING_OUTBOUND);
   }
 
+  /* 출고 완료 전후로 출고 대기 여부가 올바르게 바뀌는지 확인한다. */
   @Test
   void isPendingOutboundReturnsTrueOnlyForPendingStatus() {
-    Order order = Order.create("ORD-20260327-001", LocalDate.of(2026, 3, 27));
+    Order order = createValidOrder();
 
     assertThat(order.isPendingOutbound()).isTrue();
 
@@ -30,38 +37,132 @@ public class OrderTest {
   }
 
 
+  /* 취소된 주문은 출고 완료 처리할 수 없는지 확인한다. */
   @Test
   void canceledOrderCannotBeMarkedAsOutboundCompleted() {
-    Order order = Order.create("ORD-20260327-001", LocalDate.of(2026, 3, 27));
+    Order order = createValidOrder();
     order.cancelOrder();
 
     assertThatThrownBy(order::markOutboundCompleted)
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Canceled order cannot be completed.");
   }
+
+  /* 주문번호가 비어 있으면 생성할 수 없는지 확인한다. */
   @Test
   void createFailsWhenOrderNoIsBlank() {
-    assertThatThrownBy(() -> Order.create(" ", LocalDate.of(2026, 3, 27)))
+    assertThatThrownBy(() -> Order.create(
+        " ",
+        LocalDate.of(2026, 3, 27),
+        List.of(createValidItem()),
+        createValidAddress()
+    ))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Order number is required.");
   }
 
+  /* 주문일자가 없으면 생성할 수 없는지 확인한다. */
   @Test
   void createFailsWhenOrderDateIsNull() {
-    assertThatThrownBy(() -> Order.create("ORD-20260327-001", null))
+    assertThatThrownBy(() -> Order.create(
+        "ORD-20260327-001",
+        null,
+        List.of(createValidItem()),
+        createValidAddress()
+    ))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Order date is required.");
   }
 
+  /* 출고 완료된 주문은 취소할 수 없는지 확인한다. */
   @Test
   void completedOrderCannotBeCanceled() {
-    Order order = Order.create("ORD-20260327-001", LocalDate.of(2026, 3, 27));
+    Order order = createValidOrder();
     order.markOutboundCompleted();
 
     assertThatThrownBy(order::cancelOrder)
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Completed order cannot be canceled.");
   }
+
+  /* 주문 항목과 배송지가 포함된 aggregate가 정상 생성되는지 확인한다. */
+  @Test
+  void createCreatesOrderWithItemsAndShippingAddress() {
+    OrderItem item = createValidItem();
+    ShippingAddress address = createValidAddress();
+
+    Order order = Order.create(
+        "ORD-20260327-001",
+        LocalDate.of(2026, 3, 27),
+        List.of(item),
+        address
+    );
+    assertThat(order.getItems()).hasSize(1);
+    assertThat(order.getShippingAddress()).isEqualTo(address);
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.PENDING_OUTBOUND);
+  }
+
+  /* 주문 항목이 비어 있으면 생성할 수 없는지 확인한다. */
+  @Test
+  void createFailsWhenItemsIsEmpty() {
+    ShippingAddress address = createValidAddress();
+
+    assertThatThrownBy(() -> Order.create(
+        "ORD-20260327-001",
+        LocalDate.of(2026, 3, 27),
+        List.of(),
+        address
+    ))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Order items are required.");
+  }
+
+  /* 주문 항목이 없으면 생성할 수 없는지 확인한다. */
+  @Test
+  void createFailsWhenItemsIsNull() {
+    assertThatThrownBy(() -> Order.create(
+        "ORD-20260327-001",
+        LocalDate.of(2026, 3, 27),
+        null,
+        createValidAddress()
+    ))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Order items are required.");
+  }
+
+  /* 배송지가 없으면 생성할 수 없는지 확인한다. */
+  @Test
+  void createFailsWhenShippingAddressIsNull() {
+    assertThatThrownBy(() -> Order.create(
+        "ORD-20260327-001",
+        LocalDate.of(2026, 3, 27),
+        List.of(createValidItem()),
+        null
+    ))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Shipping address is required.");
+  }
+
+  private Order createValidOrder() {
+    return Order.create(
+        "ORD-20260327-001",
+        LocalDate.of(2026, 3, 27),
+        List.of(createValidItem()),
+        createValidAddress()
+    );
+  }
+
+  private OrderItem createValidItem() {
+    return OrderItem.create("SKU-001", 2);
+  }
+
+  private ShippingAddress createValidAddress() {
+    return ShippingAddress.create(
+        "서울시 강남구 테헤란로 123",
+        "101동 202호",
+        "Seoul",
+        "Seoul",
+        "06236"
+    );
+  }
 }
-
-

--- a/src/test/java/com/conk/order/command/domain/aggregate/ShippingAddressTest.java
+++ b/src/test/java/com/conk/order/command/domain/aggregate/ShippingAddressTest.java
@@ -1,0 +1,56 @@
+package com.conk.order.command.domain.aggregate;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/* ShippingAddress 도메인 규칙 테스트
+*
+* 배송지는 주문 배송을 위한 기본주소 정보이며,
+* 핵심 필수값이 비어 있으면 생성될 수 없어야 한다.
+* */
+public class ShippingAddressTest {
+
+  /* 필수 주소 정보로 배송지가 정상 생성되는지 확인한다. */
+  @Test
+  void createCreatesShippingAddressWithRequiredFields() {
+    ShippingAddress shippingAddress = ShippingAddress.create(
+        "서울시 강남구 테헤란로 123",
+        "101동 202호",
+        "Seoul",
+        "Seoul",
+        "06236"
+    );
+
+  assertThat(shippingAddress.getAddress1()).isEqualTo("서울시 강남구 테헤란로 123");
+  assertThat(shippingAddress.getAddress2()).isEqualTo("101동 202호");
+  assertThat(shippingAddress.getCity()).isEqualTo("Seoul");
+  assertThat(shippingAddress.getState()).isEqualTo("Seoul");
+  assertThat(shippingAddress.getZipCode()).isEqualTo("06236");
+  }
+
+  /* 기본 주소가 비어 있으면 생성할 수 없는지 확인한다. */
+  @Test
+  void createFailsWhenAddress1IsBlank() {
+    assertThatThrownBy(() -> ShippingAddress.create(" ", "101동 202호", "Seoul", "Seoul", "06236"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Address1 is required.");
+  }
+
+  /* 도시 정보가 비어 있으면 생성할 수 없는지 확인한다. */
+  @Test
+  void createFailsWhenCityIsBlank() {
+    assertThatThrownBy(() -> ShippingAddress.create("서울시 강남구 태헤란로 123", "101동 200호", " ", "Seoul", "06236"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("City is required.");
+  }
+
+  /* 우편번호가 비어 있으면 생성할 수 없는지 확인한다. */
+  @Test
+  void createFailsWhenZipCodeIsBlank() {
+    assertThatThrownBy(() -> ShippingAddress.create("서울시 강남구 테헤란로 123", "101동 202호", "Seoul", "Seoul", " "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Zip code is required.");
+  }
+}


### PR DESCRIPTION
  ## 📝 변경 사항
  - 주문 도메인을 aggregate 기준으로 정리했습니다.
  - `Order`, `OrderItem`, `ShippingAddress` 구조를 맞추고 도메인 테스트를 보강했습니다.
  - 이후 JPA 매핑과 Repository 테스트로 이어갈 수 있는 최소 골격을 만들었습니다.

  ## 🔍 주요 작업 내용
  - [x] Backend: `Order`에 주문 항목, 배송지 필드와 aggregate 생성 규칙 추가
  - [x] Backend: `Order.create(...)`를 aggregate 기준으로 정리하고 필수값 검증 추가
  - [x] Backend: `OrderItem`, `ShippingAddress` 도메인 객체 및 테스트 추가
  - [x] Backend: `OrderTest`를 aggregate 기준으로 통일하고 예외 케이스 보강
  - [x] Backend: 테스트 메서드에 짧은 한글 설명 주석 추가
  - [ ] Frontend: 없음
  - [ ] DB: JPA 매핑/Repository 단계는 아직 미진행

  ## 📸 스크린샷 (선택)
  - 없음

  ## 💬 리뷰어에게 한마디
  - 이번 PR은 API 구현 전 주문 aggregate 도메인 구조를 먼저 고정하는 작업입니다.
  - 다음 단계에서 JPA 매핑, `OrderRepository`, `@DataJpaTest`로 DB 연결 테스트를 진행할 예정입니다.