### PR TITLE
feat: 주문 레포지토리 계층 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
+
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/src/main/java/com/conk/order/command/domain/aggregate/Order.java
+++ b/src/main/java/com/conk/order/command/domain/aggregate/Order.java
@@ -1,20 +1,32 @@
 package com.conk.order.command.domain.aggregate;
 
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
 import lombok.Getter;
-
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Entity
+@Table(name = "orders")
 public class Order {
 
-  private final String orderNo;
-  private final LocalDate orderDate;
-  private OrderStatus status;
-  private final List<OrderItem> items;
-  private final ShippingAddress shippingAddress;
+  @Id
+  private String orderNo;
 
+  private LocalDate orderDate;
+
+  @Enumerated(EnumType.STRING)
+  private OrderStatus status;
+
+  @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<OrderItem> items = new ArrayList<>();
+
+  @Embedded
+  private ShippingAddress shippingAddress;
+
+
+  protected Order(){}
   /*
    * 외부에서 직접 생성자를 호출하지 못하게 막고,
    * create() 팩토리 메서드를 통해 생성 규칙을 강제한다.
@@ -32,9 +44,12 @@ public class Order {
     validateShippingAddress(shippingAddress);
     this.orderNo = orderNo;
     this.orderDate = orderDate;
-    this.items = items;
     this.shippingAddress = shippingAddress;
     this.status = status;
+
+    for (OrderItem item : items) {
+      addItem(item);
+    }
   }
 
   /**
@@ -92,6 +107,11 @@ public class Order {
       throw new IllegalStateException("Completed order cannot be canceled.");
     }
     this.status = OrderStatus.CANCELED;
+  }
+
+  private void addItem(OrderItem item) {
+    item.assignOrder(this);
+    this.items.add(item);
   }
 
   /**

--- a/src/main/java/com/conk/order/command/domain/aggregate/OrderItem.java
+++ b/src/main/java/com/conk/order/command/domain/aggregate/OrderItem.java
@@ -1,5 +1,6 @@
 package com.conk.order.command.domain.aggregate;
 
+import jakarta.persistence.*;
 import lombok.Getter;
 
 /*
@@ -9,9 +10,21 @@ import lombok.Getter;
  * 현재 단계에서는 SKU와 수량만 최소 필드로 둔다.
  *   */
 @Getter
+@Entity
 public class OrderItem {
-  private final String sku;
-  private final int quantity;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "order_no")
+  private Order order;
+
+  private String sku;
+  private int quantity;
+
+  protected OrderItem() {}
 
   private OrderItem(String sku, int quantity) {
     validateSku(sku);
@@ -22,6 +35,10 @@ public class OrderItem {
 
   public static OrderItem create(String sku, int quantity) {
     return new OrderItem(sku, quantity);
+  }
+
+  void assignOrder(Order order) {
+    this.order = order;
   }
 
   private void validateSku(String sku) {

--- a/src/main/java/com/conk/order/command/domain/aggregate/ShippingAddress.java
+++ b/src/main/java/com/conk/order/command/domain/aggregate/ShippingAddress.java
@@ -1,5 +1,7 @@
 package com.conk.order.command.domain.aggregate;
 
+
+import jakarta.persistence.Embeddable;
 import lombok.Getter;
 
 /*
@@ -9,13 +11,16 @@ import lombok.Getter;
  *   현재 단계에서는 필수 주소 정보 최소한으로 검증한다.
  * */
 @Getter
+@Embeddable
 public class ShippingAddress {
 
-  private final String address1;
-  private final String address2;
-  private final String city;
-  private final String state;
-  private final String zipCode;
+  private String address1;
+  private String address2;
+  private String city;
+  private String state;
+  private String zipCode;
+
+  protected ShippingAddress() {}
 
   private ShippingAddress(String address1, String address2, String city, String state, String zipCode) {
     validateAddress1(address1);

--- a/src/main/java/com/conk/order/command/domain/repository/OrderRepository.java
+++ b/src/main/java/com/conk/order/command/domain/repository/OrderRepository.java
@@ -1,0 +1,10 @@
+package com.conk.order.command.domain.repository;
+
+import com.conk.order.command.domain.aggregate.Order;
+import com.conk.order.command.domain.aggregate.OrderStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, String> {
+
+  Long countByStatus(OrderStatus status);
+}

--- a/src/test/java/com/conk/order/command/domain/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/conk/order/command/domain/repository/OrderRepositoryTest.java
@@ -1,0 +1,63 @@
+package com.conk.order.command.domain.repository;
+
+import com.conk.order.command.domain.aggregate.Order;
+import com.conk.order.command.domain.aggregate.OrderItem;
+import com.conk.order.command.domain.aggregate.OrderStatus;
+import com.conk.order.command.domain.aggregate.ShippingAddress;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class OrderRepositoryTest {
+
+  @Autowired
+  private OrderRepository orderRepository;
+
+  @Test
+  void savePersistsOrderAggregate() {
+    Order order = createOrder("ORD-001");
+
+    Order saved = orderRepository.saveAndFlush(order);
+    Order found = orderRepository.findById(saved.getOrderNo()).orElseThrow();
+
+    assertThat(found.getOrderNo()).isEqualTo("ORD-001");
+    assertThat(found.getItems()).hasSize(1);
+    assertThat(found.getShippingAddress().getCity()).isEqualTo("Seoul");
+  }
+
+  @Test
+  void countByStatusReturnsPendingOutboundCount() {
+    Order pending1 = createOrder("ORD-001");
+    Order pending2 = createOrder("ORD-002");
+    Order completed = createOrder("ORD-003");
+    completed.markOutboundCompleted();
+
+    orderRepository.saveAll(List.of(pending1, pending2, completed));
+    orderRepository.flush();
+
+    Long count = orderRepository.countByStatus(OrderStatus.PENDING_OUTBOUND);
+
+    assertThat(count).isEqualTo(2L);
+  }
+
+  private Order createOrder(String orderNo) {
+    return Order.create(
+        orderNo,
+        LocalDate.of(2026, 3, 30),
+        List.of(OrderItem.create("SKU-001", 2)),
+        ShippingAddress.create(
+            "서울시 강남구 테헤란로 123",
+            "101동 202호",
+            "Seoul",
+            "Seoul",
+            "06236"
+        )
+    );
+  }
+}


### PR DESCRIPTION
  ## 📝 변경 사항
  - 주문 aggregate를 JPA 기준으로 저장/조회할 수 있도록 Repository 계층을 추가했습니다.
  - `Order`, `OrderItem`, `ShippingAddress` 매핑을 반영하고 `OrderRepository`를 작성했습니다.
  - Repository 테스트를 통해 aggregate 저장과 상태 기반 카운트 조회를 검증했습니다.

  ## 🔍 주요 작업 내용
  - [x] Backend: `Order`, `OrderItem`, `ShippingAddress` JPA 매핑 반영
  - [x] Backend: `OrderRepository` 추가
  - [x] Backend: `OrderRepositoryTest` 작성
  - [x] Backend: 주문 aggregate 저장 테스트 추가
  - [x] Backend: `countByStatus(PENDING_OUTBOUND)` 조회 테스트 추가
  - [x] Backend: `build.gradle`에 Repository 테스트용 의존성 반영
  - [ ] Frontend: 없음
  - [ ] DB: 실제 dev DB 연동 전, 테스트 기준 저장/조회 검증까지 완료

  ## 📸 스크린샷 (선택)
  - 없음

  ## 💬 리뷰어에게 한마디
  - 이번 단계는 `5-2 Repository 계층`까지 완료하는 작업입니다.
  - 다음 단계에서 `ORD-001 /orders/outbound/stats` 서비스 테스트와 응답 조립 로직으로 넘어갈 예정입니다.