### PR TITLE
feat: ORD-002 셀러 단건 주문 등록 구현

### DIFF
--- a/docs/order-dev-log.md
+++ b/docs/order-dev-log.md
@@ -341,3 +341,40 @@
 
 ### 마지막 커밋 내용 :
 - `feat: ORD-001 출고 통계 조회 컨트롤러 구현 및 trendLabel 수정`
+
+## 2026-04-03 (2)
+
+### 현재단계 :
+- ORD-002 `POST /orders/seller/manual` 셀러 단건 주문 등록 기능 구현.
+- TDD Inside-Out: Service Test → Service → Controller Test → Controller 순 진행.
+
+### 작업 브랜치 :
+- `feat/order-create-manual`
+
+### 구현 시 바뀌는 점 :
+- `POST /orders/seller/manual` 엔드포인트 추가.
+- `orderNo` 는 null 이면 UUID 자동 생성, 값 있으면 중복 검증 후 사용.
+- 응답 래퍼 `ApiResponse` 에 `message` 필드 추가 (`@JsonInclude(NON_NULL)` 로 조회 응답에는 미포함).
+- `command/port/OrderSavePort` 인터페이스 추가 — 서비스가 JpaRepository 전체가 아닌 최소 포트에만 의존.
+
+### 추가하는 코드
+- `command/port/OrderSavePort.java` — `save`, `existsById` 최소 포트 인터페이스
+- `command/dto/CreateOrderRequest.java` — 요청 DTO (Bean Validation 포함)
+- `command/dto/CreateOrderItemRequest.java` — 항목 요청 DTO
+- `command/dto/CreateShippingAddressRequest.java` — 배송지 요청 DTO
+- `command/dto/CreateOrderResponse.java` — 응답 DTO (orderNo)
+- `command/service/CreateOrderService.java` — 주문 등록 서비스
+- `command/controller/CreateOrderController.java` — 주문 등록 컨트롤러
+- `query/dto/ApiResponse.java` — message 필드 및 `created()` 팩토리 메서드 추가
+
+### 테스트
+- `CreateOrderServiceTest` 5개 GREEN (orderNo 자동생성/직접입력, 중복예외, RECEIVED 상태, 항목 수)
+- `CreateOrderControllerTest` 3개 GREEN (정상 201, sellerId 누락 400, items 누락 400)
+- 전체 39개 GREEN
+
+### 확인해야할 점 :
+- `orderChannel` 은 현재 MANUAL 고정. 추후 다른 채널 API 추가 시 분리 고려.
+- 통합 테스트 (`@SpringBootTest`) 는 미작성 — 필요 시 추가.
+
+### 마지막 커밋 내용 :
+- `feat: ORD-002 셀러 단건 주문 등록 구현`

--- a/docs/order-development-plan.md
+++ b/docs/order-development-plan.md
@@ -32,7 +32,7 @@
 
 | API ID | Method | Path | 요약 | 상태 | 시작일 | 완료일 | 작업 브랜치 | 테스트 관점 | 비고 |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| ORD-002 | POST | /orders/seller/manual | 셀러 단건 주문 등록 | 대기 | - | - | - | 요청 필수값 검증, 상품 항목 수량 검증, 생성 응답 래퍼 검증 | 생성 API |
+| ORD-002 | POST | /orders/seller/manual | 셀러 단건 주문 등록 | 완료 | 2026-04-03 | 2026-04-03 | feat/order-create-manual | 요청 필수값 검증, 상품 항목 수량 검증, 생성 응답 래퍼 검증 | orderNo 는 null 이면 UUID 자동 생성, 값 있으면 중복 검증. ApiResponse 에 message 필드 추가 (NON_NULL 직렬화). 전체 39개 GREEN |
 | ORD-003 | POST | /orders/seller/bulk | 셀러 엑셀 업로드 주문 일괄 등록 | 대기 | - | - | - | 다건 요청 검증, 부분 실패 정책 확인, 생성 응답 래퍼 검증 | 생성 API |
 
 ### (2) Seller 주문 조회

--- a/src/main/java/com/conk/order/command/controller/CreateOrderController.java
+++ b/src/main/java/com/conk/order/command/controller/CreateOrderController.java
@@ -1,0 +1,32 @@
+package com.conk.order.command.controller;
+
+import com.conk.order.command.dto.CreateOrderRequest;
+import com.conk.order.command.dto.CreateOrderResponse;
+import com.conk.order.command.service.CreateOrderService;
+import com.conk.order.query.dto.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/* ORD-002 셀러 단건 주문 등록 컨트롤러. */
+@RestController
+@RequestMapping("/orders")
+public class CreateOrderController {
+
+  private final CreateOrderService createOrderService;
+
+  public CreateOrderController(CreateOrderService createOrderService) {
+    this.createOrderService = createOrderService;
+  }
+
+  @PostMapping("/seller/manual")
+  @ResponseStatus(HttpStatus.CREATED)
+  public ApiResponse<CreateOrderResponse> createOrder(@Valid @RequestBody CreateOrderRequest request) {
+    CreateOrderResponse response = createOrderService.create(request);
+    return ApiResponse.created("주문이 등록되었습니다.", response);
+  }
+}

--- a/src/main/java/com/conk/order/command/domain/repository/OrderRepository.java
+++ b/src/main/java/com/conk/order/command/domain/repository/OrderRepository.java
@@ -2,9 +2,19 @@ package com.conk.order.command.domain.repository;
 
 import com.conk.order.command.domain.aggregate.Order;
 import com.conk.order.command.domain.aggregate.OrderStatus;
+import com.conk.order.command.port.OrderSavePort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderRepository extends JpaRepository<Order, String> {
+/*
+ * JpaRepository 가 existsById 를 제공하므로 OrderSavePort 의 중복 체크는 별도 구현이 필요 없다.
+ * saveOrder() 는 JpaRepository.save() 를 위임해 이름 충돌을 피한다.
+ */
+public interface OrderRepository extends JpaRepository<Order, String>, OrderSavePort {
 
   Long countByStatus(OrderStatus status);
+
+  @Override
+  default void saveOrder(Order order) {
+    save(order);
+  }
 }

--- a/src/main/java/com/conk/order/command/dto/CreateOrderItemRequest.java
+++ b/src/main/java/com/conk/order/command/dto/CreateOrderItemRequest.java
@@ -1,0 +1,21 @@
+package com.conk.order.command.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+/* 주문 항목 요청 DTO. */
+@Getter
+public class CreateOrderItemRequest {
+
+  /** SKU 코드 (필수). */
+  @NotBlank
+  private String sku;
+
+  /** 주문 수량 (필수, 1 이상). */
+  @Min(1)
+  private int quantity;
+
+  /** 주문 시점 상품명 스냅샷 (선택). */
+  private String productNameSnapshot;
+}

--- a/src/main/java/com/conk/order/command/dto/CreateOrderRequest.java
+++ b/src/main/java/com/conk/order/command/dto/CreateOrderRequest.java
@@ -1,0 +1,53 @@
+package com.conk.order.command.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+
+/*
+ * 셀러 단건 주문 등록 요청 DTO.
+ *
+ * orderNo 는 선택값이다.
+ * - null 이면 서버가 UUID 로 자동 생성한다.
+ * - 값이 있으면 해당 값을 사용하며 중복 여부를 검증한다.
+ * orderChannel 은 이 엔드포인트 전용으로 MANUAL 로 고정된다.
+ */
+@Getter
+public class CreateOrderRequest {
+
+  /** 주문번호 (선택). null 이면 서버 자동 생성. */
+  private String orderNo;
+
+  /** 셀러 식별자 (필수). */
+  @NotBlank
+  private String sellerId;
+
+  /** 주문 일시 (필수). */
+  @NotNull
+  private LocalDateTime orderedAt;
+
+  /** 주문 항목 목록 (필수, 1개 이상). */
+  @NotEmpty
+  @Valid
+  private List<CreateOrderItemRequest> items;
+
+  /** 배송지 정보 (필수). */
+  @NotNull
+  @Valid
+  private CreateShippingAddressRequest shippingAddress;
+
+  /** 수령인 이름 (필수). */
+  @NotBlank
+  private String receiverName;
+
+  /** 수령인 연락처 (필수). */
+  @NotBlank
+  private String receiverPhoneNo;
+
+  /** 메모 (선택). */
+  private String memo;
+}

--- a/src/main/java/com/conk/order/command/dto/CreateOrderResponse.java
+++ b/src/main/java/com/conk/order/command/dto/CreateOrderResponse.java
@@ -1,0 +1,13 @@
+package com.conk.order.command.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/* 주문 등록 응답 DTO. */
+@Getter
+@RequiredArgsConstructor
+public class CreateOrderResponse {
+
+  /** 생성된 주문번호. */
+  private final String orderNo;
+}

--- a/src/main/java/com/conk/order/command/dto/CreateShippingAddressRequest.java
+++ b/src/main/java/com/conk/order/command/dto/CreateShippingAddressRequest.java
@@ -1,0 +1,27 @@
+package com.conk.order.command.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+/* 배송지 요청 DTO. */
+@Getter
+public class CreateShippingAddressRequest {
+
+  /** 기본 주소 (필수). */
+  @NotBlank
+  private String address1;
+
+  /** 상세 주소 (선택). */
+  private String address2;
+
+  /** 도시 (필수). */
+  @NotBlank
+  private String city;
+
+  /** 주/도 (선택). */
+  private String state;
+
+  /** 우편번호 (필수). */
+  @NotBlank
+  private String zipCode;
+}

--- a/src/main/java/com/conk/order/command/port/OrderSavePort.java
+++ b/src/main/java/com/conk/order/command/port/OrderSavePort.java
@@ -1,0 +1,19 @@
+package com.conk.order.command.port;
+
+import com.conk.order.command.domain.aggregate.Order;
+
+/*
+ * 주문 저장 포트.
+ *
+ * CreateOrderService 가 의존하는 최소 인터페이스로,
+ * 서비스 단위 테스트 시 Stub 구현체로 교체할 수 있다.
+ * 프로덕션에서는 OrderRepository 가 이 인터페이스를 구현한다.
+ */
+public interface OrderSavePort {
+
+  /** 주문번호 중복 여부를 반환한다. */
+  boolean existsById(String orderNo);
+
+  /** 주문을 저장한다. */
+  void saveOrder(Order order);
+}

--- a/src/main/java/com/conk/order/command/service/CreateOrderService.java
+++ b/src/main/java/com/conk/order/command/service/CreateOrderService.java
@@ -1,0 +1,82 @@
+package com.conk.order.command.service;
+
+import com.conk.order.command.domain.aggregate.Order;
+import com.conk.order.command.domain.aggregate.OrderChannel;
+import com.conk.order.command.domain.aggregate.OrderItem;
+import com.conk.order.command.domain.aggregate.ShippingAddress;
+import com.conk.order.command.dto.CreateOrderItemRequest;
+import com.conk.order.command.dto.CreateOrderRequest;
+import com.conk.order.command.dto.CreateOrderResponse;
+import com.conk.order.command.dto.CreateShippingAddressRequest;
+import com.conk.order.command.port.OrderSavePort;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+/* ORD-002 셀러 단건 주문 등록 서비스. */
+@Service
+public class CreateOrderService {
+
+  private final OrderSavePort orderSavePort;
+
+  public CreateOrderService(OrderSavePort orderSavePort) {
+    this.orderSavePort = orderSavePort;
+  }
+
+  /**
+   * 주문을 등록하고 생성된 주문번호를 반환한다.
+   *
+   * <p>orderNo 가 null 이면 UUID 로 자동 생성한다.
+   * orderNo 가 전달되면 해당 값을 사용하되, 이미 존재하면 예외를 던진다.
+   */
+  public CreateOrderResponse create(CreateOrderRequest request) {
+    String orderNo = resolveOrderNo(request.getOrderNo());
+
+    Order order = Order.create(
+        orderNo,
+        request.getOrderedAt(),
+        request.getSellerId(),
+        OrderChannel.MANUAL,
+        toOrderItems(request.getItems()),
+        toShippingAddress(request.getShippingAddress()),
+        request.getReceiverName(),
+        request.getReceiverPhoneNo(),
+        request.getMemo()
+    );
+
+    orderSavePort.saveOrder(order);
+    return new CreateOrderResponse(orderNo);
+  }
+
+  /*
+   * 요청에 orderNo 가 있으면 중복 여부를 확인하고 반환한다.
+   * 없으면 UUID 를 생성해 반환한다.
+   */
+  private String resolveOrderNo(String requested) {
+    if (requested == null || requested.isBlank()) {
+      return UUID.randomUUID().toString();
+    }
+    if (orderSavePort.existsById(requested)) {
+      throw new IllegalArgumentException("이미 존재하는 주문번호입니다: " + requested);
+    }
+    return requested;
+  }
+
+  /* 요청 항목 목록을 도메인 OrderItem 으로 변환한다. */
+  private List<OrderItem> toOrderItems(List<CreateOrderItemRequest> items) {
+    return items.stream()
+        .map(i -> OrderItem.create(i.getSku(), i.getQuantity(), i.getProductNameSnapshot()))
+        .toList();
+  }
+
+  /* 요청 배송지를 도메인 ShippingAddress 로 변환한다. */
+  private ShippingAddress toShippingAddress(CreateShippingAddressRequest req) {
+    return ShippingAddress.create(
+        req.getAddress1(),
+        req.getAddress2(),
+        req.getCity(),
+        req.getState(),
+        req.getZipCode()
+    );
+  }
+}

--- a/src/main/java/com/conk/order/query/dto/ApiResponse.java
+++ b/src/main/java/com/conk/order/query/dto/ApiResponse.java
@@ -1,20 +1,35 @@
 package com.conk.order.query.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
-/* 조회 API 공통 응답 래퍼. */
+/*
+ * API 공통 응답 래퍼.
+ *
+ * - 조회 API: success(data) — message 는 null 이므로 JSON 에 포함되지 않는다.
+ * - 생성 API: created(message, data) — { success, message, data } 형태로 직렬화된다.
+ */
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 인 필드는 JSON 응답에 넣지 않겠다는 어노테이션
 public class ApiResponse<T> {
 
   private final boolean success;
+  private final String message;
   private final T data;
 
-  private ApiResponse(boolean success, T data) {
+  private ApiResponse(boolean success, String message, T data) {
     this.success = success;
+    this.message = message;
     this.data = data;
   }
 
+  /* 조회 API 응답. { success: true, data: {...} } */
   public static <T> ApiResponse<T> success(T data) {
-    return new ApiResponse<>(true, data);
+    return new ApiResponse<>(true, null, data);
+  }
+
+  /* 생성 API 응답. { success: true, message: "...", data: {...} } */
+  public static <T> ApiResponse<T> created(String message, T data) {
+    return new ApiResponse<>(true, message, data);
   }
 }

--- a/src/test/java/com/conk/order/command/controller/CreateOrderControllerTest.java
+++ b/src/test/java/com/conk/order/command/controller/CreateOrderControllerTest.java
@@ -1,0 +1,92 @@
+package com.conk.order.command.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.conk.order.command.dto.CreateOrderResponse;
+import com.conk.order.command.service.CreateOrderService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/* ORD-002 셀러 단건 주문 등록 컨트롤러 단위 테스트. */
+@WebMvcTest(CreateOrderController.class)
+class CreateOrderControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private CreateOrderService createOrderService;
+
+  /* 정상 요청 시 201 Created 와 success/message/data 형식으로 응답한다. */
+  @Test
+  void createOrder_returnsCreatedWithOrderNo() throws Exception {
+    given(createOrderService.create(org.mockito.ArgumentMatchers.any()))
+        .willReturn(new CreateOrderResponse("ORD-UUID-001"));
+
+    String requestBody = objectMapper.writeValueAsString(buildRequestBody());
+
+    mockMvc.perform(post("/orders/seller/manual")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.message").value("주문이 등록되었습니다."))
+        .andExpect(jsonPath("$.data.orderNo").value("ORD-UUID-001"));
+  }
+
+  /* sellerId 가 없으면 400 Bad Request 를 반환한다. */
+  @Test
+  void createOrder_returnsBadRequest_whenSellerIdMissing() throws Exception {
+    Map<String, Object> body = buildRequestBody();
+    body.remove("sellerId");
+
+    mockMvc.perform(post("/orders/seller/manual")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(body)))
+        .andExpect(status().isBadRequest());
+  }
+
+  /* items 가 없으면 400 Bad Request 를 반환한다. */
+  @Test
+  void createOrder_returnsBadRequest_whenItemsMissing() throws Exception {
+    Map<String, Object> body = buildRequestBody();
+    body.remove("items");
+
+    mockMvc.perform(post("/orders/seller/manual")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(body)))
+        .andExpect(status().isBadRequest());
+  }
+
+  // ── 헬퍼 ──────────────────────────────────────────────────────────────────
+
+  /* 기본 요청 바디를 Map 으로 구성한다. Map 이므로 필드 제거 테스트에 편리하다. */
+  private Map<String, Object> buildRequestBody() {
+    return new java.util.HashMap<>(Map.of(
+        "sellerId", "SELLER-001",
+        "orderedAt", LocalDateTime.of(2026, 4, 3, 10, 0).toString(),
+        "items", List.of(Map.of("sku", "SKU-001", "quantity", 2)),
+        "shippingAddress", Map.of(
+            "address1", "서울시 강남구 테헤란로 123",
+            "city", "Seoul",
+            "zipCode", "06236"
+        ),
+        "receiverName", "홍길동",
+        "receiverPhoneNo", "010-1234-5678"
+    ));
+  }
+}

--- a/src/test/java/com/conk/order/command/service/CreateOrderServiceTest.java
+++ b/src/test/java/com/conk/order/command/service/CreateOrderServiceTest.java
@@ -1,0 +1,155 @@
+package com.conk.order.command.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.conk.order.command.domain.aggregate.Order;
+import com.conk.order.command.domain.aggregate.OrderStatus;
+import com.conk.order.command.dto.CreateOrderItemRequest;
+import com.conk.order.command.dto.CreateOrderRequest;
+import com.conk.order.command.dto.CreateOrderResponse;
+import com.conk.order.command.dto.CreateShippingAddressRequest;
+import com.conk.order.command.port.OrderSavePort;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/* ORD-002 셀러 단건 주문 등록 서비스 단위 테스트. */
+class CreateOrderServiceTest {
+
+  private StubOrderSavePort stubPort;
+  private CreateOrderService service;
+
+  @BeforeEach
+  void setUp() {
+    stubPort = new StubOrderSavePort();
+    service = new CreateOrderService(stubPort);
+  }
+
+  /* orderNo 를 전달하지 않으면 서버가 UUID 를 생성해 반환한다. */
+  @Test
+  void create_generatesOrderNo_whenNotProvided() {
+    CreateOrderRequest request = buildRequest(null);
+
+    CreateOrderResponse response = service.create(request);
+
+    assertThat(response.getOrderNo()).isNotBlank();
+    assertThat(stubPort.savedOrders).hasSize(1);
+    assertThat(stubPort.savedOrders.values().iterator().next().getOrderNo())
+        .isEqualTo(response.getOrderNo());
+  }
+
+  /* orderNo 를 전달하면 해당 값을 그대로 사용한다. */
+  @Test
+  void create_usesProvidedOrderNo_whenGiven() {
+    CreateOrderRequest request = buildRequest("ORD-CUSTOM-001");
+
+    CreateOrderResponse response = service.create(request);
+
+    assertThat(response.getOrderNo()).isEqualTo("ORD-CUSTOM-001");
+  }
+
+  /* 동일한 orderNo 가 이미 존재하면 예외를 던진다. */
+  @Test
+  void create_throws_whenOrderNoAlreadyExists() {
+    CreateOrderRequest first = buildRequest("ORD-DUP-001");
+    service.create(first);
+
+    CreateOrderRequest duplicate = buildRequest("ORD-DUP-001");
+
+    assertThatThrownBy(() -> service.create(duplicate))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("ORD-DUP-001");
+  }
+
+  /* 저장된 주문의 상태는 RECEIVED 이다. */
+  @Test
+  void create_savesOrderWithReceivedStatus() {
+    service.create(buildRequest(null));
+
+    Order saved = stubPort.savedOrders.values().iterator().next();
+
+    assertThat(saved.getStatus()).isEqualTo(OrderStatus.RECEIVED);
+  }
+
+  /* 저장된 주문의 항목 수가 요청과 일치한다. */
+  @Test
+  void create_savesCorrectItemCount() {
+    service.create(buildRequest(null));
+
+    Order saved = stubPort.savedOrders.values().iterator().next();
+
+    assertThat(saved.getItems()).hasSize(2);
+  }
+
+  // ── 헬퍼 ──────────────────────────────────────────────────────────────────
+
+  /*
+   * 기본 주문 요청을 생성한다.
+   * orderNo 가 null 이면 서버 자동 생성, 값이 있으면 해당 값을 사용한다.
+   */
+  private CreateOrderRequest buildRequest(String orderNo) {
+    CreateOrderRequest request = new CreateOrderRequest();
+    setField(request, "orderNo", orderNo);
+    setField(request, "sellerId", "SELLER-001");
+    setField(request, "orderedAt", LocalDateTime.of(2026, 4, 3, 10, 0));
+    setField(request, "items", List.of(
+        buildItem("SKU-001", 2, "상품 A"),
+        buildItem("SKU-002", 1, null)
+    ));
+    setField(request, "shippingAddress", buildAddress());
+    setField(request, "receiverName", "홍길동");
+    setField(request, "receiverPhoneNo", "010-1234-5678");
+    setField(request, "memo", null);
+    return request;
+  }
+
+  private CreateOrderItemRequest buildItem(String sku, int quantity, String name) {
+    CreateOrderItemRequest item = new CreateOrderItemRequest();
+    setField(item, "sku", sku);
+    setField(item, "quantity", quantity);
+    setField(item, "productNameSnapshot", name);
+    return item;
+  }
+
+  private CreateShippingAddressRequest buildAddress() {
+    CreateShippingAddressRequest addr = new CreateShippingAddressRequest();
+    setField(addr, "address1", "서울시 강남구 테헤란로 123");
+    setField(addr, "address2", null);
+    setField(addr, "city", "Seoul");
+    setField(addr, "state", null);
+    setField(addr, "zipCode", "06236");
+    return addr;
+  }
+
+  /* 리플렉션으로 DTO 필드를 설정한다 (Lombok @Getter 전용 DTO 는 setter 가 없음). */
+  private static void setField(Object target, String fieldName, Object value) {
+    try {
+      Field field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /* 저장된 주문을 메모리에 보관하는 테스트용 Stub. */
+  private static class StubOrderSavePort implements OrderSavePort {
+
+    final Map<String, Order> savedOrders = new HashMap<>();
+
+    @Override
+    public boolean existsById(String orderNo) {
+      return savedOrders.containsKey(orderNo);
+    }
+
+    @Override
+    public void saveOrder(Order order) {
+      savedOrders.put(order.getOrderNo(), order);
+    }
+  }
+}


### PR DESCRIPTION
---
## 📝 작업 내용
- `POST /orders/seller/manual` 셀러 단건 주문 등록 엔드포인트 구현
- `orderNo` null 이면 UUID 자동 생성, 값 전달 시 중복 여부 검증 후 사용
- `OrderSavePort` 최소 포트 인터페이스 도입 — 서비스가 JpaRepository 전체가 아닌 2개 메서드에만 의존
- `ApiResponse` 에 `message` 필드 추가 (`@JsonInclude(NON_NULL)`) 및 `created()` 팩토리 메서드 추가
- Bean Validation(`@NotBlank`, `@NotNull`, `@NotEmpty`, `@Min`) 으로 요청 필수값 검증 → 실패 시 400

## 📂 관련 파일 (Scope)
- `command/port/OrderSavePort.java` — 신규
- `command/dto/CreateOrderRequest.java` — 신규
- `command/dto/CreateOrderItemRequest.java` — 신규
- `command/dto/CreateShippingAddressRequest.java` — 신규
- `command/dto/CreateOrderResponse.java` — 신규
- `command/service/CreateOrderService.java` — 신규
- `command/controller/CreateOrderController.java` — 신규
- `query/dto/ApiResponse.java` — message 필드 및 created() 추가
- `command/domain/repository/OrderRepository.java` — OrderSavePort 구현 추가

## 🎯 관련 이슈
- Close #ord-002

## ⚠️ 유의사항 및 특이사항
- `orderChannel` 은 이 엔드포인트 전용으로 `MANUAL` 고정
- 통합 테스트(`@SpringBootTest`) 는 미작성 — 필요 시 후속 추가 가능
- `OrderSavePort.saveOrder()` 메서드명은 JpaRepository.save() 와 반환 타입 충돌 방지를 위해 구분

## ✅ 체크리스트
- [x] 커밋 내역이 정리되어 있는가?
- [x] 불필요한 파일이 없는가?