### PR TITLE
feat: 송장 CSV 다운로드 API 구현

### DIFF
--- a/src/main/java/com/conk/order/query/application/controller/ShipmentExportController.java
+++ b/src/main/java/com/conk/order/query/application/controller/ShipmentExportController.java
@@ -1,0 +1,46 @@
+package com.conk.order.query.application.controller;
+
+import com.conk.order.query.application.service.ShipmentExportService;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/*
+ * 송장 CSV 다운로드 컨트롤러.
+ *
+ * GET /orders/shipments/export
+ * 관리자용. OUTBOUND_COMPLETED 상태의 비연동 채널 주문 송장을 CSV 로 내려준다.
+ */
+@RestController
+@RequestMapping("/orders/shipments")
+public class ShipmentExportController {
+
+  private final ShipmentExportService shipmentExportService;
+
+  public ShipmentExportController(ShipmentExportService shipmentExportService) {
+    this.shipmentExportService = shipmentExportService;
+  }
+
+  /* 송장 CSV 를 다운로드한다. */
+  @GetMapping("/export")
+  public ResponseEntity<byte[]> exportCsv() {
+    String csv = shipmentExportService.exportCsv();
+
+    // UTF-8 BOM 추가 (엑셀에서 한글 깨짐 방지)
+    byte[] bom = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+    byte[] csvBytes = csv.getBytes(StandardCharsets.UTF_8);
+    byte[] body = new byte[bom.length + csvBytes.length];
+    System.arraycopy(bom, 0, body, 0, bom.length);
+    System.arraycopy(csvBytes, 0, body, bom.length, csvBytes.length);
+
+    return ResponseEntity.ok()
+        .header(HttpHeaders.CONTENT_DISPOSITION,
+            "attachment; filename=shipment_export.csv")
+        .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
+        .body(body);
+  }
+}

--- a/src/main/java/com/conk/order/query/application/dto/ShipmentExportRow.java
+++ b/src/main/java/com/conk/order/query/application/dto/ShipmentExportRow.java
@@ -1,0 +1,51 @@
+package com.conk.order.query.application.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/*
+ * 송장 CSV 다운로드용 행 데이터.
+ *
+ * MyBatis 쿼리 결과를 매핑한다.
+ * OUTBOUND_COMPLETED 상태의 비연동 채널(MANUAL, EXCEL) 주문 대상.
+ */
+@Getter
+@Setter
+public class ShipmentExportRow {
+
+  /** 주문번호. */
+  private String orderId;
+
+  /** 송장번호. */
+  private String invoiceNo;
+
+  /** 주문 채널. */
+  private String orderChannel;
+
+  /** 수령인 이름. */
+  private String receiverName;
+
+  /** 수령인 연락처. */
+  private String receiverPhoneNo;
+
+  /** 기본주소. */
+  private String address1;
+
+  /** 상세주소. */
+  private String address2;
+
+  /** 도시. */
+  private String city;
+
+  /** 주/지역. */
+  private String state;
+
+  /** 우편번호. */
+  private String zipCode;
+
+  /** 국가. */
+  private String country;
+
+  /** 출고 완료 일시. */
+  private String shippedAt;
+}

--- a/src/main/java/com/conk/order/query/application/service/ShipmentExportService.java
+++ b/src/main/java/com/conk/order/query/application/service/ShipmentExportService.java
@@ -1,0 +1,61 @@
+package com.conk.order.query.application.service;
+
+import com.conk.order.query.application.dto.ShipmentExportRow;
+import com.conk.order.query.infrastructure.mapper.ShipmentExportQueryMapper;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/*
+ * 송장 CSV 다운로드 서비스.
+ *
+ * OUTBOUND_COMPLETED 상태의 비연동 채널 주문을 조회하고
+ * CSV 문자열로 변환한다.
+ */
+@Service
+public class ShipmentExportService {
+
+  private static final String CSV_HEADER =
+      "주문번호,송장번호,채널,수령인,연락처,기본주소,상세주소,도시,주/지역,우편번호,국가,출고일시";
+
+  private final ShipmentExportQueryMapper shipmentExportQueryMapper;
+
+  public ShipmentExportService(ShipmentExportQueryMapper shipmentExportQueryMapper) {
+    this.shipmentExportQueryMapper = shipmentExportQueryMapper;
+  }
+
+  /* 출고 완료된 비연동 채널 주문을 CSV 문자열로 반환한다. */
+  @Transactional(readOnly = true)
+  public String exportCsv() {
+    List<ShipmentExportRow> rows = shipmentExportQueryMapper.findShipmentExportRows();
+
+    StringBuilder sb = new StringBuilder();
+    sb.append(CSV_HEADER).append("\n");
+
+    for (ShipmentExportRow row : rows) {
+      sb.append(escape(row.getOrderId())).append(",");
+      sb.append(escape(row.getInvoiceNo())).append(",");
+      sb.append(escape(row.getOrderChannel())).append(",");
+      sb.append(escape(row.getReceiverName())).append(",");
+      sb.append(escape(row.getReceiverPhoneNo())).append(",");
+      sb.append(escape(row.getAddress1())).append(",");
+      sb.append(escape(row.getAddress2())).append(",");
+      sb.append(escape(row.getCity())).append(",");
+      sb.append(escape(row.getState())).append(",");
+      sb.append(escape(row.getZipCode())).append(",");
+      sb.append(escape(row.getCountry())).append(",");
+      sb.append(escape(row.getShippedAt())).append("\n");
+    }
+
+    return sb.toString();
+  }
+
+  /* CSV 특수문자(쉼표, 따옴표, 줄바꿈) 를 이스케이프한다. null 은 빈 문자열로 처리. */
+  private String escape(String value) {
+    if (value == null) return "";
+    if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+      return "\"" + value.replace("\"", "\"\"") + "\"";
+    }
+    return value;
+  }
+}

--- a/src/main/java/com/conk/order/query/infrastructure/mapper/ShipmentExportQueryMapper.java
+++ b/src/main/java/com/conk/order/query/infrastructure/mapper/ShipmentExportQueryMapper.java
@@ -1,0 +1,17 @@
+package com.conk.order.query.infrastructure.mapper;
+
+import com.conk.order.query.application.dto.ShipmentExportRow;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+/*
+ * 송장 CSV 다운로드용 MyBatis Mapper.
+ *
+ * OUTBOUND_COMPLETED 상태의 비연동 채널(MANUAL, EXCEL) 주문을 조회한다.
+ */
+@Mapper
+public interface ShipmentExportQueryMapper {
+
+  /* 출고 완료된 비연동 채널 주문의 송장 정보를 조회한다. */
+  List<ShipmentExportRow> findShipmentExportRows();
+}

--- a/src/main/resources/mappers/ShipmentExportQueryMapper.xml
+++ b/src/main/resources/mappers/ShipmentExportQueryMapper.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+  송장 CSV 다운로드용 MyBatis 쿼리.
+  OUTBOUND_COMPLETED 상태의 비연동 채널(MANUAL, EXCEL) 주문을 조회한다.
+-->
+<mapper namespace="com.conk.order.query.infrastructure.mapper.ShipmentExportQueryMapper">
+
+  <select id="findShipmentExportRows"
+          resultType="com.conk.order.query.application.dto.ShipmentExportRow">
+    SELECT o.order_id       AS orderId,
+           o.invoice_no     AS invoiceNo,
+           o.order_channel  AS orderChannel,
+           o.receiver_name  AS receiverName,
+           o.receiver_phone_no AS receiverPhoneNo,
+           o.ship_to_address1  AS address1,
+           o.ship_to_address2  AS address2,
+           o.ship_to_city      AS city,
+           o.ship_to_state     AS state,
+           o.ship_to_zip_code  AS zipCode,
+           o.ship_to_country   AS country,
+           o.shipped_at        AS shippedAt
+      FROM sales_order o
+     WHERE o.status = 'OUTBOUND_COMPLETED'
+       AND o.order_channel IN ('MANUAL', 'EXCEL')
+     ORDER BY o.shipped_at DESC
+  </select>
+
+</mapper>

--- a/src/test/java/com/conk/order/query/application/controller/ShipmentExportIntegrationTest.java
+++ b/src/test/java/com/conk/order/query/application/controller/ShipmentExportIntegrationTest.java
@@ -1,0 +1,90 @@
+package com.conk.order.query.application.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.conk.order.command.domain.aggregate.Order;
+import com.conk.order.command.domain.aggregate.OrderChannel;
+import com.conk.order.command.domain.aggregate.OrderItem;
+import com.conk.order.command.domain.aggregate.OrderStatus;
+import com.conk.order.command.domain.aggregate.ShippingAddress;
+import com.conk.order.command.domain.repository.OrderRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+/*
+ * 송장 CSV 다운로드 통합 테스트.
+ *
+ * 검증 대상:
+ *   - OUTBOUND_COMPLETED + MANUAL/EXCEL 채널 주문만 CSV 에 포함
+ *   - CSV 헤더 + 데이터 행 형식 검증
+ *   - 데이터 없으면 헤더만 반환
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class ShipmentExportIntegrationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private OrderRepository orderRepository;
+
+  /* 출고 완료된 MANUAL 주문이 CSV 에 포함된다. */
+  @Test
+  void exportCsv_includesOutboundCompletedManualOrders() throws Exception {
+    Order order = createOrder("ORD-CSV-001", OrderChannel.MANUAL);
+    // 상태를 OUTBOUND_COMPLETED 까지 진행
+    order.changeStatus(OrderStatus.ALLOCATED);
+    order.changeStatus(OrderStatus.OUTBOUND_INSTRUCTED);
+    order.changeStatus(OrderStatus.PICKING);
+    order.changeStatus(OrderStatus.PACKING);
+    order.changeStatus(OrderStatus.OUTBOUND_COMPLETED);
+    orderRepository.save(order);
+
+    MvcResult result = mockMvc.perform(get("/orders/shipments/export"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Content-Disposition",
+            "attachment; filename=shipment_export.csv"))
+        .andReturn();
+
+    String csv = result.getResponse().getContentAsString();
+    assertThat(csv).contains("주문번호,송장번호");
+    assertThat(csv).contains("ORD-CSV-001");
+  }
+
+  /* 데이터가 없으면 헤더만 반환한다. */
+  @Test
+  void exportCsv_returnsHeaderOnly_whenNoData() throws Exception {
+    MvcResult result = mockMvc.perform(get("/orders/shipments/export"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    String csv = result.getResponse().getContentAsString();
+    String[] lines = csv.trim().split("\n");
+    assertThat(lines).hasSize(1);
+    assertThat(lines[0]).contains("주문번호");
+  }
+
+  // ── 헬퍼 ──────────────────────────────────────────────────────────────────
+
+  private Order createOrder(String orderId, OrderChannel channel) {
+    return Order.create(
+        orderId, LocalDateTime.of(2026, 4, 9, 10, 0), "SELLER-001",
+        channel,
+        List.of(OrderItem.create("SKU-001", 1, "상품A")),
+        ShippingAddress.create("123 Main St", null, "LA", "CA", "90001"),
+        "홍길동", "010-1234-5678", null
+    );
+  }
+}


### PR DESCRIPTION
---
## 📝 작업 내용
- ORD-012: 송장 CSV 다운로드 (GET /orders/shipments/export)
  - OUTBOUND_COMPLETED + MANUAL/EXCEL 채널 주문 대상
  - UTF-8 BOM 추가로 엑셀 한글 깨짐 방지
  - CSV 특수문자(쉼표, 따옴표, 줄바꿈) 이스케이프 처리

## 📂 관련 파일 (Scope)
- query/application/dto/ShipmentExportRow.java — [NEW]
- query/infrastructure/mapper/ShipmentExportQueryMapper.java — [NEW]
- mappers/ShipmentExportQueryMapper.xml — [NEW]
- query/application/service/ShipmentExportService.java — [NEW]
- query/application/controller/ShipmentExportController.java — [NEW]

## ✅ 체크리스트
- [x] 전체 테스트 통과 (BUILD SUCCESSFUL)
- [x] 커밋 내역이 정리되어 있는가?