### PR TITLE
feat: 주문 상태 트래킹 API 구현 (ORD-009)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,14 @@
     "allow": [
       "Bash(gh auth status && git branch --show-current222)",
       "Bash(gh auth status && git branch --show-current && git status --short)",
-      "WebFetch(domain:www.erdcloud.com)"
+      "WebFetch(domain:www.erdcloud.com)",
+      "Bash(sed -i '' -e 's/private String orderNo;/private String orderId;/' -e 's/public String getOrderNo\\(\\)/public String getOrderId\\(\\)/' src/main/java/com/conk/order/command/application/dto/CreateOrderRequest.java)",
+      "Bash(sed -i '' -e 's/private final String orderNo;/private final String orderId;/' src/main/java/com/conk/order/command/application/dto/CreateOrderResponse.java)",
+      "Bash(sed -i '' -e 's/String orderNo = resolveOrderNo\\(request\\\\.getOrderNo\\(\\)\\)/String orderId = resolveOrderId\\(request.getOrderId\\(\\)\\)/' -e 's/return new CreateOrderResponse\\(orderNo\\);/return new CreateOrderResponse\\(orderId\\);/' -e 's/private String resolveOrderNo/private String resolveOrderId/' -e 's/request\\\\.getOrderNo\\(\\)/request.getOrderId\\(\\)/g' src/main/java/com/conk/order/command/application/service/CreateOrderService.java)",
+      "Bash(sed -i '' -e 's/        orderNo,/        orderId,/' src/main/java/com/conk/order/command/application/service/CreateOrderService.java)",
+      "Bash(./gradlew test:*)",
+      "Bash(xargs ls:*)",
+      "Bash(grep -l \"IntegrationTest\\\\|@SpringBootTest\" /Users/jeongbyeongjin/SWCAMP22/be22-final-team1-project/team1-backend-order/src/test/java/com/conk/order/**/*.java)"
     ]
   }
 }

--- a/src/main/java/com/conk/order/command/application/service/CancelOrderService.java
+++ b/src/main/java/com/conk/order/command/application/service/CancelOrderService.java
@@ -1,7 +1,10 @@
 package com.conk.order.command.application.service;
 
 import com.conk.order.command.domain.aggregate.Order;
+import com.conk.order.command.domain.aggregate.OrderStatus;
+import com.conk.order.command.domain.aggregate.OrderStatusHistory;
 import com.conk.order.command.domain.repository.OrderRepository;
+import com.conk.order.command.domain.repository.OrderStatusHistoryRepository;
 import com.conk.order.common.exception.BusinessException;
 import com.conk.order.common.exception.ErrorCode;
 import org.springframework.stereotype.Service;
@@ -12,14 +15,18 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * RECEIVED, ALLOCATED 상태의 주문만 취소 가능하다.
  * 셀러 본인의 주문인지 검증한 뒤 Order.cancelOrder() 를 호출한다.
+ * 취소 시 히스토리를 기록한다.
  */
 @Service
 public class CancelOrderService {
 
   private final OrderRepository orderRepository;
+  private final OrderStatusHistoryRepository historyRepository;
 
-  public CancelOrderService(OrderRepository orderRepository) {
+  public CancelOrderService(OrderRepository orderRepository,
+      OrderStatusHistoryRepository historyRepository) {
     this.orderRepository = orderRepository;
+    this.historyRepository = historyRepository;
   }
 
   /*
@@ -38,10 +45,15 @@ public class CancelOrderService {
       throw new BusinessException(ErrorCode.ORDER_NOT_FOUND);
     }
 
+    OrderStatus fromStatus = order.getStatus();
+
     try {
       order.cancelOrder();
     } catch (IllegalStateException e) {
       throw new BusinessException(ErrorCode.ORDER_CANCEL_NOT_ALLOWED);
     }
+
+    historyRepository.save(
+        OrderStatusHistory.create(orderId, fromStatus, OrderStatus.CANCELED, sellerId));
   }
 }

--- a/src/main/java/com/conk/order/command/application/service/UpdateOrderStatusService.java
+++ b/src/main/java/com/conk/order/command/application/service/UpdateOrderStatusService.java
@@ -2,7 +2,10 @@ package com.conk.order.command.application.service;
 
 import com.conk.order.command.application.dto.UpdateOrderStatusRequest;
 import com.conk.order.command.domain.aggregate.Order;
+import com.conk.order.command.domain.aggregate.OrderStatus;
+import com.conk.order.command.domain.aggregate.OrderStatusHistory;
 import com.conk.order.command.domain.repository.OrderRepository;
+import com.conk.order.command.domain.repository.OrderStatusHistoryRepository;
 import com.conk.order.common.exception.BusinessException;
 import com.conk.order.common.exception.ErrorCode;
 import org.springframework.stereotype.Service;
@@ -12,15 +15,18 @@ import org.springframework.transaction.annotation.Transactional;
  * 주문 상태 변경 서비스.
  *
  * 주문을 조회한 뒤 도메인 규칙(OrderStatus.canTransitionTo) 에 따라
- * 상태를 변경한다. JPA dirty checking 으로 자동 저장된다.
+ * 상태를 변경한다. 변경 시 히스토리를 기록한다.
  */
 @Service
 public class UpdateOrderStatusService {
 
   private final OrderRepository orderRepository;
+  private final OrderStatusHistoryRepository historyRepository;
 
-  public UpdateOrderStatusService(OrderRepository orderRepository) {
+  public UpdateOrderStatusService(OrderRepository orderRepository,
+      OrderStatusHistoryRepository historyRepository) {
     this.orderRepository = orderRepository;
+    this.historyRepository = historyRepository;
   }
 
   /*
@@ -35,10 +41,15 @@ public class UpdateOrderStatusService {
     Order order = orderRepository.findById(orderId)
         .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
+    OrderStatus fromStatus = order.getStatus();
+
     try {
       order.changeStatus(request.getStatus());
     } catch (IllegalStateException e) {
       throw new BusinessException(ErrorCode.ORDER_STATUS_TRANSITION_NOT_ALLOWED);
     }
+
+    historyRepository.save(
+        OrderStatusHistory.create(orderId, fromStatus, request.getStatus(), null));
   }
 }

--- a/src/main/java/com/conk/order/command/domain/aggregate/OrderStatusHistory.java
+++ b/src/main/java/com/conk/order/command/domain/aggregate/OrderStatusHistory.java
@@ -1,0 +1,58 @@
+package com.conk.order.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+/*
+ * 주문 상태 변경 히스토리 엔티티.
+ *
+ * 주문 상태가 변경될 때마다 이전 상태 → 새 상태를 기록한다.
+ * 물리 테이블: order_status_history
+ */
+@Getter
+@Entity
+@Table(name = "order_status_history")
+public class OrderStatusHistory {
+
+  /** 히스토리 식별자. 자동 생성. */
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  /** 소속 주문번호. */
+  @Column(name = "order_id", nullable = false)
+  private String orderId;
+
+  /** 변경 전 상태. 최초 생성 시 null. */
+  @Column(name = "from_status")
+  @Enumerated(EnumType.STRING)
+  private OrderStatus fromStatus;
+
+  /** 변경 후 상태. */
+  @Column(name = "to_status", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private OrderStatus toStatus;
+
+  /** 변경 일시. */
+  @Column(name = "changed_at", nullable = false)
+  private LocalDateTime changedAt;
+
+  /** 변경자. */
+  @Column(name = "changed_by")
+  private String changedBy;
+
+  protected OrderStatusHistory() {}
+
+  /** 상태 변경 히스토리를 생성한다. */
+  public static OrderStatusHistory create(
+      String orderId, OrderStatus fromStatus, OrderStatus toStatus, String changedBy) {
+    OrderStatusHistory history = new OrderStatusHistory();
+    history.orderId = orderId;
+    history.fromStatus = fromStatus;
+    history.toStatus = toStatus;
+    history.changedAt = LocalDateTime.now();
+    history.changedBy = changedBy;
+    return history;
+  }
+}

--- a/src/main/java/com/conk/order/command/domain/repository/OrderStatusHistoryRepository.java
+++ b/src/main/java/com/conk/order/command/domain/repository/OrderStatusHistoryRepository.java
@@ -1,0 +1,14 @@
+package com.conk.order.command.domain.repository;
+
+import com.conk.order.command.domain.aggregate.OrderStatusHistory;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/*
+ * 주문 상태 변경 히스토리 레포지토리.
+ */
+public interface OrderStatusHistoryRepository extends JpaRepository<OrderStatusHistory, Long> {
+
+  /* 주문번호로 히스토리를 시간순으로 조회한다. */
+  List<OrderStatusHistory> findByOrderIdOrderByChangedAtAsc(String orderId);
+}

--- a/src/main/java/com/conk/order/query/application/controller/OrderTrackingQueryController.java
+++ b/src/main/java/com/conk/order/query/application/controller/OrderTrackingQueryController.java
@@ -1,0 +1,37 @@
+package com.conk.order.query.application.controller;
+
+import com.conk.order.common.dto.ApiResponse;
+import com.conk.order.query.application.dto.OrderTrackingResponse;
+import com.conk.order.query.application.service.OrderTrackingQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/*
+ * 주문 상태 트래킹 컨트롤러.
+ *
+ * GET /orders/seller/{orderId}/tracking
+ * 셀러 본인 주문의 상태 변경 이력을 시간순으로 반환한다.
+ */
+@RestController
+@RequestMapping("/orders/seller")
+public class OrderTrackingQueryController {
+
+  private final OrderTrackingQueryService orderTrackingQueryService;
+
+  public OrderTrackingQueryController(OrderTrackingQueryService orderTrackingQueryService) {
+    this.orderTrackingQueryService = orderTrackingQueryService;
+  }
+
+  /* 주문 상태 변경 이력을 조회한다. */
+  @GetMapping("/{orderId}/tracking")
+  public ResponseEntity<ApiResponse<OrderTrackingResponse>> getTracking(
+      @PathVariable String orderId,
+      @RequestHeader("X-User-Id") String sellerId) {
+    OrderTrackingResponse response = orderTrackingQueryService.getTracking(orderId, sellerId);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+}

--- a/src/main/java/com/conk/order/query/application/dto/OrderTrackingResponse.java
+++ b/src/main/java/com/conk/order/query/application/dto/OrderTrackingResponse.java
@@ -1,0 +1,53 @@
+package com.conk.order.query.application.dto;
+
+import com.conk.order.command.domain.aggregate.OrderStatus;
+import com.conk.order.command.domain.aggregate.OrderStatusHistory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+
+/*
+ * 주문 상태 트래킹 응답 DTO.
+ *
+ * GET /orders/seller/{orderId}/tracking 응답으로 사용한다.
+ * 주문의 상태 변경 이력을 시간순으로 반환한다.
+ */
+@Getter
+public class OrderTrackingResponse {
+
+  /** 주문번호. */
+  private final String orderId;
+
+  /** 현재 상태. */
+  private final OrderStatus currentStatus;
+
+  /** 상태 변경 이력 목록 (시간순). */
+  private final List<StatusChange> history;
+
+  public OrderTrackingResponse(String orderId, OrderStatus currentStatus,
+      List<StatusChange> history) {
+    this.orderId = orderId;
+    this.currentStatus = currentStatus;
+    this.history = history;
+  }
+
+  /** 개별 상태 변경 이력. */
+  @Getter
+  public static class StatusChange {
+    private final OrderStatus fromStatus;
+    private final OrderStatus toStatus;
+    private final LocalDateTime changedAt;
+    private final String changedBy;
+
+    private StatusChange(OrderStatusHistory h) {
+      this.fromStatus = h.getFromStatus();
+      this.toStatus = h.getToStatus();
+      this.changedAt = h.getChangedAt();
+      this.changedBy = h.getChangedBy();
+    }
+
+    public static StatusChange from(OrderStatusHistory h) {
+      return new StatusChange(h);
+    }
+  }
+}

--- a/src/main/java/com/conk/order/query/application/service/OrderTrackingQueryService.java
+++ b/src/main/java/com/conk/order/query/application/service/OrderTrackingQueryService.java
@@ -1,0 +1,51 @@
+package com.conk.order.query.application.service;
+
+import com.conk.order.command.domain.aggregate.Order;
+import com.conk.order.command.domain.aggregate.OrderStatusHistory;
+import com.conk.order.command.domain.repository.OrderRepository;
+import com.conk.order.command.domain.repository.OrderStatusHistoryRepository;
+import com.conk.order.common.exception.BusinessException;
+import com.conk.order.common.exception.ErrorCode;
+import com.conk.order.query.application.dto.OrderTrackingResponse;
+import com.conk.order.query.application.dto.OrderTrackingResponse.StatusChange;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/*
+ * 주문 상태 트래킹 조회 서비스.
+ *
+ * 셀러 본인 주문의 상태 변경 이력을 시간순으로 반환한다.
+ */
+@Service
+public class OrderTrackingQueryService {
+
+  private final OrderRepository orderRepository;
+  private final OrderStatusHistoryRepository historyRepository;
+
+  public OrderTrackingQueryService(OrderRepository orderRepository,
+      OrderStatusHistoryRepository historyRepository) {
+    this.orderRepository = orderRepository;
+    this.historyRepository = historyRepository;
+  }
+
+  /* 주문 상태 변경 이력을 조회한다. */
+  @Transactional(readOnly = true)
+  public OrderTrackingResponse getTracking(String orderId, String sellerId) {
+    Order order = orderRepository.findById(orderId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+    if (!order.getSellerId().equals(sellerId)) {
+      throw new BusinessException(ErrorCode.ORDER_NOT_FOUND);
+    }
+
+    List<OrderStatusHistory> histories =
+        historyRepository.findByOrderIdOrderByChangedAtAsc(orderId);
+
+    List<StatusChange> changes = histories.stream()
+        .map(StatusChange::from)
+        .toList();
+
+    return new OrderTrackingResponse(orderId, order.getStatus(), changes);
+  }
+}

--- a/src/test/java/com/conk/order/command/application/service/CancelOrderServiceTest.java
+++ b/src/test/java/com/conk/order/command/application/service/CancelOrderServiceTest.java
@@ -2,14 +2,18 @@ package com.conk.order.command.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.conk.order.command.domain.aggregate.Order;
 import com.conk.order.command.domain.aggregate.OrderChannel;
 import com.conk.order.command.domain.aggregate.OrderItem;
 import com.conk.order.command.domain.aggregate.OrderStatus;
 import com.conk.order.command.domain.aggregate.ShippingAddress;
+import com.conk.order.command.domain.aggregate.OrderStatusHistory;
 import com.conk.order.command.domain.repository.OrderRepository;
+import com.conk.order.command.domain.repository.OrderStatusHistoryRepository;
 import com.conk.order.common.exception.BusinessException;
 import com.conk.order.common.exception.ErrorCode;
 import java.time.LocalDateTime;
@@ -36,6 +40,9 @@ class CancelOrderServiceTest {
   @Mock
   private OrderRepository orderRepository;
 
+  @Mock
+  private OrderStatusHistoryRepository historyRepository;
+
   @InjectMocks
   private CancelOrderService cancelOrderService;
 
@@ -48,6 +55,7 @@ class CancelOrderServiceTest {
     cancelOrderService.cancel("ORD-001", "SELLER-001");
 
     assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+    verify(historyRepository).save(any(OrderStatusHistory.class));
   }
 
   /* 존재하지 않는 주문 → ORDER_NOT_FOUND. */

--- a/src/test/java/com/conk/order/command/application/service/UpdateOrderStatusServiceTest.java
+++ b/src/test/java/com/conk/order/command/application/service/UpdateOrderStatusServiceTest.java
@@ -2,7 +2,9 @@ package com.conk.order.command.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.conk.order.command.application.dto.UpdateOrderStatusRequest;
 import com.conk.order.command.domain.aggregate.Order;
@@ -10,7 +12,9 @@ import com.conk.order.command.domain.aggregate.OrderChannel;
 import com.conk.order.command.domain.aggregate.OrderItem;
 import com.conk.order.command.domain.aggregate.OrderStatus;
 import com.conk.order.command.domain.aggregate.ShippingAddress;
+import com.conk.order.command.domain.aggregate.OrderStatusHistory;
 import com.conk.order.command.domain.repository.OrderRepository;
+import com.conk.order.command.domain.repository.OrderStatusHistoryRepository;
 import com.conk.order.common.exception.BusinessException;
 import com.conk.order.common.exception.ErrorCode;
 import java.time.LocalDateTime;
@@ -36,6 +40,9 @@ class UpdateOrderStatusServiceTest {
   @Mock
   private OrderRepository orderRepository;
 
+  @Mock
+  private OrderStatusHistoryRepository historyRepository;
+
   @InjectMocks
   private UpdateOrderStatusService updateOrderStatusService;
 
@@ -51,6 +58,7 @@ class UpdateOrderStatusServiceTest {
     updateOrderStatusService.updateStatus("ORD-001", request);
 
     assertThat(order.getStatus()).isEqualTo(OrderStatus.ALLOCATED);
+    verify(historyRepository).save(any(OrderStatusHistory.class));
   }
 
   /* 존재하지 않는 주문 → ORDER_NOT_FOUND 예외. */

--- a/src/test/java/com/conk/order/query/application/controller/OrderTrackingQueryIntegrationTest.java
+++ b/src/test/java/com/conk/order/query/application/controller/OrderTrackingQueryIntegrationTest.java
@@ -1,0 +1,126 @@
+package com.conk.order.query.application.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.conk.order.command.domain.aggregate.Order;
+import com.conk.order.command.domain.aggregate.OrderChannel;
+import com.conk.order.command.domain.aggregate.OrderItem;
+import com.conk.order.command.domain.aggregate.ShippingAddress;
+import com.conk.order.command.domain.repository.OrderRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/*
+ * 주문 상태 트래킹 통합 테스트.
+ *
+ * 검증 대상:
+ *   - 상태 변경 후 트래킹 조회 시 이력이 포함됨
+ *   - 주문 취소 후 트래킹에 CANCELED 이력 포함
+ *   - 이력이 없으면 빈 리스트 반환
+ *   - 타 셀러 접근 시 404
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class OrderTrackingQueryIntegrationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private OrderRepository orderRepository;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  /* 상태 변경 후 트래킹을 조회하면 이력이 포함된다. */
+  @Test
+  void getTracking_returnsHistoryAfterStatusChange() throws Exception {
+    Order order = createOrder("ORD-TRACK-001", "SELLER-001");
+    orderRepository.save(order);
+
+    // RECEIVED → ALLOCATED 상태 변경
+    mockMvc.perform(patch("/orders/ORD-TRACK-001/status")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(Map.of("status", "ALLOCATED"))))
+        .andExpect(status().isOk());
+
+    // 트래킹 조회
+    mockMvc.perform(get("/orders/seller/ORD-TRACK-001/tracking")
+            .header("X-User-Id", "SELLER-001"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.orderId").value("ORD-TRACK-001"))
+        .andExpect(jsonPath("$.data.currentStatus").value("ALLOCATED"))
+        .andExpect(jsonPath("$.data.history.length()").value(1))
+        .andExpect(jsonPath("$.data.history[0].fromStatus").value("RECEIVED"))
+        .andExpect(jsonPath("$.data.history[0].toStatus").value("ALLOCATED"));
+  }
+
+  /* 취소 후 트래킹에 CANCELED 이력이 포함된다. */
+  @Test
+  void getTracking_includesCancelHistory() throws Exception {
+    Order order = createOrder("ORD-TRACK-002", "SELLER-001");
+    orderRepository.save(order);
+
+    // 주문 취소
+    mockMvc.perform(patch("/orders/seller/ORD-TRACK-002/cancel")
+            .header("X-User-Id", "SELLER-001"))
+        .andExpect(status().isOk());
+
+    // 트래킹 조회
+    mockMvc.perform(get("/orders/seller/ORD-TRACK-002/tracking")
+            .header("X-User-Id", "SELLER-001"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.currentStatus").value("CANCELED"))
+        .andExpect(jsonPath("$.data.history[0].fromStatus").value("RECEIVED"))
+        .andExpect(jsonPath("$.data.history[0].toStatus").value("CANCELED"));
+  }
+
+  /* 이력이 없으면 빈 리스트를 반환한다. */
+  @Test
+  void getTracking_returnsEmptyHistory_whenNoChanges() throws Exception {
+    Order order = createOrder("ORD-TRACK-003", "SELLER-001");
+    orderRepository.save(order);
+
+    mockMvc.perform(get("/orders/seller/ORD-TRACK-003/tracking")
+            .header("X-User-Id", "SELLER-001"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.currentStatus").value("RECEIVED"))
+        .andExpect(jsonPath("$.data.history.length()").value(0));
+  }
+
+  /* 타 셀러가 접근하면 404. */
+  @Test
+  void getTracking_returns404_whenDifferentSeller() throws Exception {
+    Order order = createOrder("ORD-TRACK-004", "SELLER-001");
+    orderRepository.save(order);
+
+    mockMvc.perform(get("/orders/seller/ORD-TRACK-004/tracking")
+            .header("X-User-Id", "SELLER-OTHER"))
+        .andExpect(status().isNotFound());
+  }
+
+  // ── 헬퍼 ──────────────────────────────────────────────────────────────────
+
+  private Order createOrder(String orderId, String sellerId) {
+    return Order.create(
+        orderId, LocalDateTime.of(2026, 4, 9, 10, 0), sellerId,
+        OrderChannel.MANUAL,
+        List.of(OrderItem.create("SKU-001", 1, null)),
+        ShippingAddress.create("123 Main St", null, "LA", "CA", "90001"),
+        "홍길동", "010-1234-5678", null
+    );
+  }
+}


### PR DESCRIPTION
ORD-009: 주문 상태 트래킹 (GET /orders/seller/{orderId}/tracking). order_status_history 테이블로 상태 변경 이력 추적. 상태 변경/취소 시 자동 히스토리 기록. 통합 테스트 4개 포함.