### PR TITLE
refactor: BulkCreate 대용량 업로드 flush/clear 기반 메모리 관리 전환

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -35,3 +35,27 @@
 - 엔티티 선도출 방식은 이후 기능 테스트의 기반 구조를 먼저 고정하는 데 유리하다.
 - 외부 도메인 소유 데이터는 참조 ID로 우선 처리하는 편이 잘못된 Aggregate 경계 설정을 피할 수 있다.
 - `ORD-001` 추이 계산은 이미 합의된 제품 규칙이 있으므로 가이드보다 프로젝트 결정을 우선한다.
+
+## 2026-04-09 BulkCreate 대용량 업로드 처리 방식
+
+### Decision
+- `ORD-003` 대용량 업로드는 JDBC batch 설정 대신 `flush + clear` 기반 메모리 관리로 처리한다.
+- `BulkCreateOrderService`는 `saveOrder()` 흐름을 유지하고, 업로드 제한값과 `flush/clear` 주기를 `order.bulk-upload.*` 설정으로 관리한다.
+- `hibernate.jdbc.batch_size`, `hibernate.order_inserts` 설정은 사용하지 않는다.
+- 기본 설정은 `max-row-limit=5000`, `flush-interval=500`으로 둔다.
+
+### Context
+- Bulk 업로드 처리에 `saveAll + hibernate.jdbc.batch_size`를 적용하는 시도가 있었지만, 이번 작업에서는 배치 최적화보다 현재 서비스 구조를 유지하는 쪽이 우선이었다.
+- 기존 서비스는 부분 저장 정책과 행 단위 실패 수집을 중심으로 작성되어 있었다.
+- 대량 업로드 시 영속성 컨텍스트 누적에 따른 메모리 사용량 증가를 완화할 필요가 있었다.
+
+### Alternatives Considered
+- `saveAll`과 Hibernate JDBC batch 설정을 유지한다.
+- 서비스 전체를 하나의 트랜잭션으로 묶고 `EntityManager.persist()` 기반으로 chunk 처리한다.
+- 현재 저장 흐름을 유지하면서 `flush + clear`만 주기적으로 호출한다.
+
+### Why
+- 현재 코드와 테스트 변경 폭을 가장 작게 유지하면서도 대량 처리 시 1차 캐시 누적을 줄일 수 있다.
+- 부분 저장과 실패 행 수집이라는 기존 서비스 의도를 크게 흔들지 않는다.
+- JDBC batch 설정은 성능 최적화 효과는 있지만, 이번 작업 목표인 처리 방식 단순화와는 맞지 않았다.
+- 운영 환경별 업로드 정책을 코드 수정 없이 조정할 수 있다.

--- a/docs/order-dev-log.md
+++ b/docs/order-dev-log.md
@@ -639,3 +639,42 @@
 
 ### 마지막 커밋 내용 :
 - 아직 기록 전
+
+---
+
+### 현재단계 :
+- ORD-003 대용량 업로드 처리 방향을 JDBC batch 기반 시도에서 `flush + clear` 기반 메모리 관리로 다시 정리하는 단계였다.
+- 기존 `saveAll + hibernate.jdbc.batch_size` 방향 대신 `saveOrder` 유지와 주기적 `flush/clear` 호출로 변경했다.
+- 업로드 제한값은 서비스 상수 대신 `application.yml` 기반 설정으로 이동했다.
+
+### 작업 브랜치 :
+- `feat/order-status-tracking`
+
+### 구현 시 바뀌는 점 :
+- Bulk 업로드는 각 주문 저장 흐름을 유지하면서 설정된 주기마다 `flush/clear`를 호출해 영속성 컨텍스트 누적을 줄인다.
+- `hibernate.jdbc.batch_size`, `order_inserts` 설정을 제거해 JDBC batch 최적화 의존 없이 동작한다.
+- 최대 업로드 행 수도 설정값으로 관리하며, 제한 초과 업로드는 서비스 진입 시 즉시 차단한다.
+
+### 추가하는 코드
+- `src/main/java/com/conk/order/command/application/service/BulkCreateOrderService.java`
+  - `saveAll` 제거
+  - `saveOrder` 후 설정된 주기마다 `flush/clear` 수행
+  - 업로드 제한 행 수를 설정 프로퍼티로 조회
+- `src/main/java/com/conk/order/command/application/config/BulkUploadProperties.java`
+  - Bulk 업로드 제한값 바인딩 전용 설정 클래스 추가
+- `src/test/java/com/conk/order/command/application/service/BulkCreateOrderServiceTest.java`
+  - 설정 주기/제한값 기반 검증 테스트로 조정
+- `src/main/resources/application.yml`
+  - `hibernate.jdbc.batch_size`, `order_inserts` 제거
+  - `order.bulk-upload.*` 설정 추가
+
+### 테스트
+- `./gradlew test --tests com.conk.order.command.application.service.BulkCreateOrderServiceTest --tests com.conk.order.command.application.controller.BulkCreateOrderIntegrationTest`
+- 결과: BUILD SUCCESSFUL
+
+### 확인해야할 점 :
+- 현재 작업은 기존 브랜치에서 진행 중이므로 후속 커밋 전 작업 브랜치 분리 필요 여부를 다시 확인해야 한다.
+- `flush/clear`는 1차 캐시 누적 완화가 목적이며, insert 라운드트립 자체를 줄이는 방식은 아니다.
+
+### 마지막 커밋 내용 :
+- 아직 기록 전

--- a/docs/order-development-plan.md
+++ b/docs/order-development-plan.md
@@ -82,6 +82,7 @@
 | REF-008 | BulkCreate 엣지 케이스 테스트 | 대기 | - | - | null cell, FORMULA 셀, 빈 행 등 |
 | REF-009 | BulkCreate 채널 MANUAL → EXCEL | 대기 | - | - | OrderChannel.EXCEL 미사용 |
 | REF-010 | Query DTO 공통 추상 클래스 도입 | 대기 | - | - | PageableOrderListQuery 추출 |
+| REF-011 | BulkCreate flush/clear 기반 메모리 관리 | 완료 | 2026-04-09 | 2026-04-09 | JDBC batch 설정 제거, 업로드 제한값 설정 분리, 관련 테스트 GREEN |
 
 ## 3. 기능 개발 시작 시 체크 항목
 

--- a/src/main/java/com/conk/order/command/application/config/BulkUploadProperties.java
+++ b/src/main/java/com/conk/order/command/application/config/BulkUploadProperties.java
@@ -1,0 +1,35 @@
+package com.conk.order.command.application.config;
+
+import jakarta.validation.constraints.Min;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/* ORD-003 대용량 업로드 설정 프로퍼티. */
+@Validated
+@Component
+@ConfigurationProperties(prefix = "order.bulk-upload")
+public class BulkUploadProperties {
+
+  @Min(1)
+  private int maxRowLimit;
+
+  @Min(1)
+  private int flushInterval;
+
+  public int getMaxRowLimit() {
+    return maxRowLimit;
+  }
+
+  public void setMaxRowLimit(int maxRowLimit) {
+    this.maxRowLimit = maxRowLimit;
+  }
+
+  public int getFlushInterval() {
+    return flushInterval;
+  }
+
+  public void setFlushInterval(int flushInterval) {
+    this.flushInterval = flushInterval;
+  }
+}

--- a/src/main/java/com/conk/order/command/application/service/BulkCreateOrderService.java
+++ b/src/main/java/com/conk/order/command/application/service/BulkCreateOrderService.java
@@ -1,5 +1,6 @@
 package com.conk.order.command.application.service;
 
+import com.conk.order.command.application.config.BulkUploadProperties;
 import com.conk.order.command.domain.aggregate.Order;
 import com.conk.order.command.domain.aggregate.OrderChannel;
 import com.conk.order.command.domain.aggregate.OrderItem;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import jakarta.persistence.EntityManager;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -28,6 +30,11 @@ import org.springframework.web.multipart.MultipartFile;
  * 엑셀 파일을 파싱해 행별로 주문을 저장한다.
  * 실패한 행은 건너뛰고 성공한 행만 저장하는 정책(부분 저장)을 따른다.
  * 각 행은 독립 트랜잭션으로 처리되므로 이 클래스에는 @Transactional 을 붙이지 않는다.
+ *
+ * 대용량 처리 최적화:
+ *   - 업로드 제한 행 수는 설정값(order.bulk-upload.max-row-limit)으로 관리
+ *   - flush/clear 주기는 설정값(order.bulk-upload.flush-interval)으로 관리
+ *   - multipart 파일 크기 10MB 제한 (application.yml)
  *
  * 엑셀 컬럼 구조 (0-indexed):
  *   0: 주문일시  1: SKU  2: 수량  3: 상품명(선택)
@@ -44,10 +51,15 @@ public class BulkCreateOrderService {
 
   private final OrderRepository orderRepository;
   private final OrderIdGenerator orderIdGenerator;
+  private final EntityManager entityManager;
+  private final BulkUploadProperties bulkUploadProperties;
 
-  public BulkCreateOrderService(OrderRepository orderRepository, OrderIdGenerator orderIdGenerator) {
+  public BulkCreateOrderService(OrderRepository orderRepository, OrderIdGenerator orderIdGenerator,
+      EntityManager entityManager, BulkUploadProperties bulkUploadProperties) {
     this.orderRepository = orderRepository;
     this.orderIdGenerator = orderIdGenerator;
+    this.entityManager = entityManager;
+    this.bulkUploadProperties = bulkUploadProperties;
   }
 
   /*
@@ -62,10 +74,17 @@ public class BulkCreateOrderService {
    */
   public BulkCreateOrderResponse create(MultipartFile file, String sellerId) {
     int successCount = 0;
+    int savedSinceLastClear = 0;
     List<FailedRow> failedRows = new ArrayList<>();
 
     try (Workbook wb = new XSSFWorkbook(file.getInputStream())) {
       Sheet sheet = wb.getSheetAt(0);
+      int totalDataRows = sheet.getLastRowNum(); // 헤더 제외 데이터 행 수
+
+      /* 행 수 제한 검증 */
+      if (totalDataRows > bulkUploadProperties.getMaxRowLimit()) {
+        throw new BusinessException(ErrorCode.BULK_ROW_LIMIT_EXCEEDED);
+      }
 
       /* 첫 번째 행(인덱스 0)은 헤더이므로 1부터 시작한다. */
       for (int i = 1; i <= sheet.getLastRowNum(); i++) {
@@ -77,10 +96,24 @@ public class BulkCreateOrderService {
           Order order = buildOrder(row, sellerId);
           orderRepository.saveOrder(order);
           successCount++;
+          savedSinceLastClear++;
+
+          /* 일정 건수마다 flush/clear 로 1차 캐시 누적을 줄인다. */
+          if (savedSinceLastClear >= bulkUploadProperties.getFlushInterval()) {
+            flushAndClear();
+            savedSinceLastClear = 0;
+          }
         } catch (Exception e) {
           failedRows.add(new FailedRow(rowNumber, e.getMessage()));
         }
       }
+
+      /* 마지막 남은 엔티티도 flush/clear 로 정리한다. */
+      if (savedSinceLastClear > 0) {
+        flushAndClear();
+      }
+    } catch (BusinessException e) {
+      throw e;
     } catch (IOException e) {
       throw new BusinessException(ErrorCode.BULK_FILE_UNREADABLE);
     } catch (Exception e) {
@@ -88,6 +121,12 @@ public class BulkCreateOrderService {
     }
 
     return new BulkCreateOrderResponse(successCount, failedRows);
+  }
+
+  /* 영속성 컨텍스트에 남은 엔티티를 반영하고 분리한다. */
+  private void flushAndClear() {
+    orderRepository.flush();
+    entityManager.clear();
   }
 
   /* 엑셀 행을 Order 도메인 객체로 변환한다. 주문 ID 는 채번 서비스가 생성한다. */

--- a/src/main/java/com/conk/order/common/exception/ErrorCode.java
+++ b/src/main/java/com/conk/order/common/exception/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
 
   /* 엑셀 일괄 등록 (Bulk) */
   BULK_FILE_UNREADABLE(HttpStatus.BAD_REQUEST, "ORD-201", "엑셀 파일을 읽을 수 없습니다."),
-  BULK_FILE_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "ORD-202", "xlsx 형식의 파일만 업로드할 수 있습니다.");
+  BULK_FILE_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "ORD-202", "xlsx 형식의 파일만 업로드할 수 있습니다."),
+  BULK_ROW_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "ORD-203", "최대 업로드 가능 행 수를 초과했습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,11 @@ spring:
   profiles:
     active: dev
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   jackson:
     serialization:
       write-dates-as-timestamps: false
@@ -26,3 +31,7 @@ mybatis:
     map-underscore-to-camel-case: true
   type-aliases-package: com.conk.order
 
+order:
+  bulk-upload:
+    max-row-limit: 5000
+    flush-interval: 500

--- a/src/test/java/com/conk/order/command/application/service/BulkCreateOrderServiceTest.java
+++ b/src/test/java/com/conk/order/command/application/service/BulkCreateOrderServiceTest.java
@@ -3,19 +3,19 @@ package com.conk.order.command.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
 
 import com.conk.order.command.application.dto.BulkCreateOrderResponse;
-import com.conk.order.command.application.service.OrderIdGenerator;
+import com.conk.order.command.application.config.BulkUploadProperties;
 import com.conk.order.command.domain.repository.OrderRepository;
 import com.conk.order.common.exception.BusinessException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.List;
+import jakarta.persistence.EntityManager;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -44,11 +44,19 @@ class BulkCreateOrderServiceTest {
   @Mock
   private OrderIdGenerator orderIdGenerator;
 
+  @Mock
+  private EntityManager entityManager;
+
   private BulkCreateOrderService service;
 
   @BeforeEach
   void setUp() {
-    service = new BulkCreateOrderService(orderRepository, orderIdGenerator);
+    service = new BulkCreateOrderService(
+        orderRepository,
+        orderIdGenerator,
+        entityManager,
+        bulkUploadProperties(5_000, 500)
+    );
     lenient().when(orderIdGenerator.generate()).thenReturn("ORD-2026-0408-00001");
   }
 
@@ -67,6 +75,8 @@ class BulkCreateOrderServiceTest {
     assertThat(response.getSuccessCount()).isEqualTo(2);
     assertThat(response.getFailedRows()).isEmpty();
     verify(orderRepository, times(2)).saveOrder(any());
+    verify(orderRepository).flush();
+    verify(entityManager).clear();
   }
 
   /* 1행 유효 + 1행 SKU 누락 → successCount=1, failedRows 1건. */
@@ -84,6 +94,9 @@ class BulkCreateOrderServiceTest {
     assertThat(response.getSuccessCount()).isEqualTo(1);
     assertThat(response.getFailedRows()).hasSize(1);
     assertThat(response.getFailedRows().get(0).getRowNumber()).isEqualTo(3); // 헤더=1, 1행=2, 2행=3
+    verify(orderRepository).saveOrder(any());
+    verify(orderRepository).flush();
+    verify(entityManager).clear();
   }
 
   /* 데이터 행이 없는 엑셀(헤더만) → successCount=0, failedRows 없음. */
@@ -95,6 +108,28 @@ class BulkCreateOrderServiceTest {
 
     assertThat(response.getSuccessCount()).isZero();
     assertThat(response.getFailedRows()).isEmpty();
+    verify(orderRepository, never()).flush();
+    verify(entityManager, never()).clear();
+  }
+
+  /* 설정한 flush interval 을 넘기면 중간 flush/clear 와 마지막 flush/clear 가 모두 호출된다. */
+  @Test
+  void create_flushesAndClearsPeriodically_whenRowsExceedInterval() throws Exception {
+    service = new BulkCreateOrderService(
+        orderRepository,
+        orderIdGenerator,
+        entityManager,
+        bulkUploadProperties(5_000, 2)
+    );
+    MultipartFile file = buildExcelWithRepeatedRows(3);
+
+    BulkCreateOrderResponse response = service.create(file, "SELLER-001");
+
+    assertThat(response.getSuccessCount()).isEqualTo(3);
+    assertThat(response.getFailedRows()).isEmpty();
+    verify(orderRepository, times(3)).saveOrder(any());
+    verify(orderRepository, times(2)).flush();
+    verify(entityManager, times(2)).clear();
   }
 
   /* xlsx 형식 아닌 파일 → BusinessException. */
@@ -106,6 +141,25 @@ class BulkCreateOrderServiceTest {
 
     assertThatThrownBy(() -> service.create(file, "SELLER-001"))
         .isInstanceOf(BusinessException.class);
+  }
+
+  /* 설정한 최대 행 수를 초과한 엑셀은 저장 전에 즉시 차단한다. */
+  @Test
+  void create_throwsException_whenRowLimitExceeded() throws Exception {
+    service = new BulkCreateOrderService(
+        orderRepository,
+        orderIdGenerator,
+        entityManager,
+        bulkUploadProperties(2, 500)
+    );
+    MultipartFile file = buildExcelWithRepeatedRows(3);
+
+    assertThatThrownBy(() -> service.create(file, "SELLER-001"))
+        .isInstanceOf(BusinessException.class);
+
+    verify(orderRepository, never()).saveOrder(any());
+    verify(orderRepository, never()).flush();
+    verify(entityManager, never()).clear();
   }
 
   // ── 헬퍼 ──────────────────────────────────────────────────────────────────
@@ -148,5 +202,52 @@ class BulkCreateOrderServiceTest {
   /* 행 데이터를 가변 인수로 편리하게 생성한다. */
   private String[] row(String... cells) {
     return cells;
+  }
+
+  /* 동일한 데이터 행을 count 만큼 반복한 엑셀 파일을 만든다. */
+  private MultipartFile buildExcelWithRepeatedRows(int count) throws IOException {
+    Workbook wb = new XSSFWorkbook();
+    Sheet sheet = wb.createSheet("orders");
+
+    Row header = sheet.createRow(0);
+    String[] headers = {"주문번호", "주문일시", "SKU", "수량", "상품명",
+        "수령인", "연락처", "주소1", "주소2", "도시", "주/지역", "우편번호", "메모"};
+    for (int i = 0; i < headers.length; i++) {
+      header.createCell(i).setCellValue(headers[i]);
+    }
+
+    for (int i = 0; i < count; i++) {
+      Row row = sheet.createRow(i + 1);
+      row.createCell(0).setCellValue("2026-04-05 10:00:00");
+      row.createCell(1).setCellValue("SKU-" + i);
+      row.createCell(2).setCellValue("1");
+      row.createCell(3).setCellValue("상품");
+      row.createCell(4).setCellValue("홍길동");
+      row.createCell(5).setCellValue("010-1111-2222");
+      row.createCell(6).setCellValue("서울시 강남구 1번지");
+      row.createCell(7).setCellValue("");
+      row.createCell(8).setCellValue("Seoul");
+      row.createCell(9).setCellValue("");
+      row.createCell(10).setCellValue("06236");
+      row.createCell(11).setCellValue("");
+    }
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    wb.write(out);
+    wb.close();
+
+    return new MockMultipartFile(
+        "file", "orders.xlsx",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        new ByteArrayInputStream(out.toByteArray())
+    );
+  }
+
+  /* 테스트마다 원하는 업로드 제한값을 주입한다. */
+  private BulkUploadProperties bulkUploadProperties(int maxRowLimit, int flushInterval) {
+    BulkUploadProperties properties = new BulkUploadProperties();
+    properties.setMaxRowLimit(maxRowLimit);
+    properties.setFlushInterval(flushInterval);
+    return properties;
   }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -26,3 +26,8 @@ mybatis:
   configuration:
     map-underscore-to-camel-case: true
   type-aliases-package: com.conk.order
+
+order:
+  bulk-upload:
+    max-row-limit: 5000
+    flush-interval: 500


### PR DESCRIPTION
## 📝 작업 내용
- `ORD-003` BulkCreate 업로드 처리 방식을 JDBC batch(`hibernate.jdbc.batch_size`, `order_inserts`) 의존에서 **주기적 `flush/clear` 호출 기반 메모리 관리**로 전환
- 업로드 제한 행 수(`max-row-limit`)와 flush 주기(`flush-interval`)를 `order.bulk-upload.*` 설정으로 외부화
- `BulkCreateOrderService`: `saveOrder` 흐름 유지, 설정 주기마다 `orderRepository.flush() + entityManager.clear()` 호출, 루프 종료 후 잔여분도 동일 처리
- 최대 행 수 초과 엑셀은 진입 시점에 `BULK_ROW_LIMIT_EXCEEDED`(ORD-203) 로 즉시 차단
- `application.yml`: multipart 10MB 제한, `order.bulk-upload.*` 기본값(`max-row-limit=5000`, `flush-interval=500`) 추가
- 단위 테스트: flush 주기 경과 시 중간 flush/clear 호출 검증, row limit 초과 차단 검증, 빈 엑셀 시 flush/clear 미호출 검증 추가
- `docs/decisions.md`, `docs/order-dev-log.md`, `docs/order-development-plan.md`(REF-011 완료) 갱신

## 📂 관련 파일 (Scope)
- `command/application/config/BulkUploadProperties.java` (신규)
- `command/application/service/BulkCreateOrderService.java`
- `common/exception/ErrorCode.java` — `BULK_ROW_LIMIT_EXCEEDED` 추가
- `src/main/resources/application.yml`, `src/test/resources/application.yml`
- `src/test/.../BulkCreateOrderServiceTest.java`
- `docs/decisions.md`, `docs/order-dev-log.md`, `docs/order-development-plan.md`

## 🎯 관련 이슈
- Close #

## ⚠️ 유의사항 및 특이사항
- 이 PR은 성능 최적화(JDBC 라운드트립 감소) 목적이 아니라 **1차 캐시 누적 완화**가 목적입니다. `hibernate.jdbc.batch_size` / `order_inserts` 설정은 의도적으로 사용하지 않습니다 (근거: `docs/decisions.md` 2026-04-09 결정).
- `BulkCreateOrderService`는 기존대로 클래스 레벨 `@Transactional` 없이 행 단위 독립 트랜잭션 정책 유지 — 부분 저장 시맨틱이 깨지지 않도록 한 것.
- `flushAndClear()` 내부에서 `IOException` 등 외부 예외는 그대로 상위 `BusinessException` 핸들러까지 전파되며, 루프 내에서 발생한 비즈니스 예외는 기존대로 `failedRows`에 수집됩니다.
- `BusinessException`을 별도 catch로 먼저 잡아 재throw하도록 처리 — 아래쪽 포괄 `catch (Exception)`이 `BULK_FILE_FORMAT_INVALID`로 덮어쓰는 것을 방지.
- `BulkUploadProperties`에 `@Validated + @Min(1)` 적용으로 설정값 누락 시 부팅 단계에서 실패.

## ✅ 체크리스트
- [x] 커밋 내역이 정리되어 있는가?
- [x] 불필요한 파일이 없는가?