### PR TITLE
fix: 셀러 주문 계약 정렬

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,10 @@ group = 'com.conk'
 version = '0.0.1-SNAPSHOT'
 description = 'team1-backend-order'
 
+ext {
+    set('springCloudVersion', "2025.0.1")
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
@@ -24,6 +28,12 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
 dependencies {
     // [모니터링] Liveness/Readiness Probe 및 Health Check 지원
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -32,6 +42,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.5'

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -88,3 +88,26 @@
 - grouped controller와 grouped service를 맞추면 의존성 그래프와 테스트 구성이 단순해진다.
 - bulk create/validate는 입력 포맷과 정책이 같아 하나의 서비스로 묶는 편이 하드코딩 제거와 정책 일관성 측면에서 유리하다.
 - 반면 `OrderIdGenerator`는 유스케이스가 아니라 지원 컴포넌트이므로 독립 유지가 맞다.
+
+## 2026-04-14 주문 등록 옵션의 상품 소스
+
+### Decision
+- `GET /orders/seller/options`의 `products`는 order DB가 아니라 WMS의 seller 상품 목록 API에서 조회한다.
+- `channels`는 order 서비스의 `OrderChannel` 중 외부 연동 채널만 노출한다.
+  - 현재는 `SHOPIFY`만 내려준다.
+- order 서비스와 WMS 간 통신은 OpenFeign으로 처리하고, base URL은 `wms.base-url` 설정으로 분리한다.
+
+### Context
+- 주문 등록 화면은 `products[].sku`, `products[].productName`, `channels[].value`, `channels[].label`을 즉시 필요로 한다.
+- order 서비스의 전용 DB에는 상품 마스터가 없고, seller 상품 마스터는 WMS가 관리한다.
+- FE는 이미 `/orders/seller/options`를 호출하고 있어 프론트 계약을 뒤집는 것보다 backend proxy를 추가하는 편이 변경 폭이 작다.
+
+### Alternatives Considered
+- order 서비스 DB에 상품 마스터를 중복 저장한다.
+- FE가 WMS 상품 API와 order 채널 API를 각각 직접 호출한다.
+- 과거 주문 이력의 SKU/상품명 스냅샷으로 옵션을 구성한다.
+
+### Why
+- 상품 마스터의 단일 소스는 WMS이므로, order 서비스가 조회 시점에 가져오는 편이 데이터 소유권과 맞다.
+- FE 계약을 유지하면서도 수동 주문 등록 화면에 필요한 SKU 선택 목록을 안정적으로 제공할 수 있다.
+- 과거 주문 이력 기반 옵션은 신규 SKU 누락과 비활성 상품 혼입 가능성이 있어 등록 화면 품질이 떨어진다.

--- a/src/main/java/com/conk/order/Team1BackendOrderApplication.java
+++ b/src/main/java/com/conk/order/Team1BackendOrderApplication.java
@@ -3,9 +3,11 @@ package com.conk.order;
 import java.time.Clock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
+@EnableFeignClients
 public class Team1BackendOrderApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/conk/order/common/exception/ErrorCode.java
+++ b/src/main/java/com/conk/order/common/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
   ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORD-003", "주문을 찾을 수 없습니다."),
   ORDER_CANCEL_NOT_ALLOWED(HttpStatus.CONFLICT, "ORD-004", "현재 상태에서는 주문을 취소할 수 없습니다."),
   ORDER_STATUS_TRANSITION_NOT_ALLOWED(HttpStatus.CONFLICT, "ORD-005", "허용되지 않는 상태 전이입니다."),
+  ORDER_OPTIONS_UNAVAILABLE(HttpStatus.INTERNAL_SERVER_ERROR, "ORD-301", "주문 등록 옵션을 불러오지 못했습니다."),
 
   /* 주문 항목 (OrderItem) */
   ORDER_ITEM_SKU_REQUIRED(HttpStatus.BAD_REQUEST, "ORD-101", "SKU는 필수입니다."),

--- a/src/main/java/com/conk/order/query/controller/SellerOrderQueryController.java
+++ b/src/main/java/com/conk/order/query/controller/SellerOrderQueryController.java
@@ -6,6 +6,7 @@ import com.conk.order.query.dto.request.SellerOrderListQuery;
 import com.conk.order.query.dto.response.OrderTrackingResponse;
 import com.conk.order.query.dto.response.SellerOrderDetailResponse;
 import com.conk.order.query.dto.response.SellerOrderListResponse;
+import com.conk.order.query.dto.response.SellerOrderOptionsResponse;
 import com.conk.order.query.service.SellerOrderQueryService;
 import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * 셀러 Actor 가 자신의 주문을 조회하는 엔드포인트를 한곳에 묶는다.
  *   - GET /orders/seller/list             : 주문 목록 (ORD-004)
+ *   - GET /orders/seller/options          : 주문 등록 옵션
  *   - GET /orders/seller/{orderId}        : 주문 상세 (canCancel 포함)
  *   - GET /orders/seller/{orderId}/tracking : 주문 상태 변경 이력
  *
@@ -56,6 +58,14 @@ public class SellerOrderQueryController {
     query.setSize(size);
 
     return ResponseEntity.ok(ApiResponse.success(sellerOrderQueryService.getSellerOrders(query)));
+  }
+
+  /* GET /orders/seller/options — 셀러 주문 등록 화면 옵션을 조회한다. */
+  @GetMapping("/options")
+  public ResponseEntity<ApiResponse<SellerOrderOptionsResponse>> getOptions(
+      @RequestHeader("X-User-Id") String sellerId) {
+    SellerOrderOptionsResponse response = sellerOrderQueryService.getOrderOptions(sellerId);
+    return ResponseEntity.ok(ApiResponse.success(response));
   }
 
   /* GET /orders/seller/{orderId} — 셀러 본인의 주문 상세를 조회한다. */

--- a/src/main/java/com/conk/order/query/dto/response/AdminOrderSummary.java
+++ b/src/main/java/com/conk/order/query/dto/response/AdminOrderSummary.java
@@ -19,8 +19,8 @@ import lombok.Setter;
 @Setter
 public class AdminOrderSummary {
 
-  /** 주문번호. sales_order.order_id */
-  private String orderNo;
+  /** 주문 식별자. sales_order.order_id */
+  private String orderId;
 
   /** 주문 일시. sales_order.ordered_at */
   private LocalDateTime orderedAt;

--- a/src/main/java/com/conk/order/query/dto/response/SellerOrderListResponse.java
+++ b/src/main/java/com/conk/order/query/dto/response/SellerOrderListResponse.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
  * {
  *   "success": true,
  *   "data": {
- *     "orders": [ { orderNo, orderedAt, status, ... }, ... ],
+ *     "orders": [ { orderId, orderedAt, status, ... }, ... ],
  *     "totalCount": 100,   ← 필터 조건에 맞는 전체 건수 (페이지 수 계산용)
  *     "page": 0,
  *     "size": 20

--- a/src/main/java/com/conk/order/query/dto/response/SellerOrderOptionsResponse.java
+++ b/src/main/java/com/conk/order/query/dto/response/SellerOrderOptionsResponse.java
@@ -1,0 +1,43 @@
+package com.conk.order.query.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+
+/*
+ * 셀러 주문 등록 화면 옵션 응답 DTO.
+ *
+ * FE 가 수동 주문 등록 화면에서 사용하는 상품 SKU 목록과 판매 채널 목록을 함께 반환한다.
+ */
+@Getter
+public class SellerOrderOptionsResponse {
+
+  private final List<ProductOption> products;
+  private final List<ChannelOption> channels;
+
+  public SellerOrderOptionsResponse(List<ProductOption> products, List<ChannelOption> channels) {
+    this.products = products == null ? List.of() : List.copyOf(products);
+    this.channels = channels == null ? List.of() : List.copyOf(channels);
+  }
+
+  @Getter
+  public static class ProductOption {
+    private final String sku;
+    private final String productName;
+
+    public ProductOption(String sku, String productName) {
+      this.sku = sku;
+      this.productName = productName;
+    }
+  }
+
+  @Getter
+  public static class ChannelOption {
+    private final String value;
+    private final String label;
+
+    public ChannelOption(String value, String label) {
+      this.value = value;
+      this.label = label;
+    }
+  }
+}

--- a/src/main/java/com/conk/order/query/dto/response/SellerOrderSummary.java
+++ b/src/main/java/com/conk/order/query/dto/response/SellerOrderSummary.java
@@ -11,7 +11,7 @@ import lombok.Setter;
  *
  * MyBatis 가 SQL 결과(ResultSet) 를 이 객체로 자동 매핑한다.
  * application.yml 의 map-underscore-to-camel-case: true 설정 덕분에
- * DB 컬럼명 order_id → orderNo (AS 별칭 필요), ordered_at → orderedAt 처럼 자동 변환된다.
+ * DB 컬럼명 order_id → orderId (AS 별칭 필요), ordered_at → orderedAt 처럼 자동 변환된다.
  *
  * @Setter 가 있어야 MyBatis 가 setter 를 통해 값을 채울 수 있다.
  */
@@ -19,8 +19,8 @@ import lombok.Setter;
 @Setter
 public class SellerOrderSummary {
 
-  /** 주문번호. SQL: o.order_id AS orderNo */
-  private String orderNo;
+  /** 주문 식별자. SQL: o.order_id AS orderId */
+  private String orderId;
 
   /** 주문 일시. SQL: o.ordered_at */
   private LocalDateTime orderedAt;

--- a/src/main/java/com/conk/order/query/dto/response/WhmOrderSummary.java
+++ b/src/main/java/com/conk/order/query/dto/response/WhmOrderSummary.java
@@ -18,8 +18,8 @@ import lombok.Setter;
 @Setter
 public class WhmOrderSummary {
 
-  /** 주문번호. */
-  private String orderNo;
+  /** 주문 식별자. */
+  private String orderId;
 
   /** 주문 일시. */
   private LocalDateTime orderedAt;

--- a/src/main/java/com/conk/order/query/service/SellerOrderQueryService.java
+++ b/src/main/java/com/conk/order/query/service/SellerOrderQueryService.java
@@ -1,6 +1,7 @@
 package com.conk.order.query.service;
 
 import com.conk.order.command.domain.aggregate.Order;
+import com.conk.order.command.domain.aggregate.OrderChannel;
 import com.conk.order.command.domain.aggregate.OrderStatusHistory;
 import com.conk.order.command.domain.repository.OrderRepository;
 import com.conk.order.command.domain.repository.OrderStatusHistoryRepository;
@@ -11,8 +12,11 @@ import com.conk.order.query.dto.response.OrderTrackingResponse;
 import com.conk.order.query.dto.response.OrderTrackingResponse.StatusChange;
 import com.conk.order.query.dto.response.SellerOrderDetailResponse;
 import com.conk.order.query.dto.response.SellerOrderListResponse;
+import com.conk.order.query.dto.response.SellerOrderOptionsResponse;
+import com.conk.order.query.dto.response.SellerOrderOptionsResponse.ChannelOption;
 import com.conk.order.query.dto.response.SellerOrderSummary;
 import com.conk.order.query.mapper.SellerOrderListQueryMapper;
+import java.util.Arrays;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,14 +35,17 @@ public class SellerOrderQueryService {
   private final SellerOrderListQueryMapper sellerOrderListQueryMapper;
   private final OrderRepository orderRepository;
   private final OrderStatusHistoryRepository historyRepository;
+  private final SellerProductOptionFetcher sellerProductOptionFetcher;
 
   public SellerOrderQueryService(
       SellerOrderListQueryMapper sellerOrderListQueryMapper,
       OrderRepository orderRepository,
-      OrderStatusHistoryRepository historyRepository) {
+      OrderStatusHistoryRepository historyRepository,
+      SellerProductOptionFetcher sellerProductOptionFetcher) {
     this.sellerOrderListQueryMapper = sellerOrderListQueryMapper;
     this.orderRepository = orderRepository;
     this.historyRepository = historyRepository;
+    this.sellerProductOptionFetcher = sellerProductOptionFetcher;
   }
 
   /* 셀러 주문 목록을 조회해 페이징 응답으로 조립한다. */
@@ -46,6 +53,18 @@ public class SellerOrderQueryService {
     List<SellerOrderSummary> orders = sellerOrderListQueryMapper.findOrders(query);
     int totalCount = sellerOrderListQueryMapper.countOrders(query);
     return new SellerOrderListResponse(orders, totalCount, query.getPage(), query.getSize());
+  }
+
+  /* 셀러 주문 등록 화면 옵션을 반환한다. */
+  @Transactional(readOnly = true)
+  public SellerOrderOptionsResponse getOrderOptions(String sellerId) {
+    return new SellerOrderOptionsResponse(
+        sellerProductOptionFetcher.fetchProducts(sellerId),
+        Arrays.stream(OrderChannel.values())
+            .filter(this::isSelectableSalesChannel)
+            .map(channel -> new ChannelOption(channel.name(), toChannelLabel(channel)))
+            .toList()
+    );
   }
 
   /* 셀러 본인의 주문 상세를 조회한다. */
@@ -78,5 +97,16 @@ public class SellerOrderQueryService {
       throw new BusinessException(ErrorCode.ORDER_NOT_FOUND);
     }
     return order;
+  }
+
+  private boolean isSelectableSalesChannel(OrderChannel channel) {
+    return channel != OrderChannel.MANUAL && channel != OrderChannel.EXCEL;
+  }
+
+  private String toChannelLabel(OrderChannel channel) {
+    return switch (channel) {
+      case SHOPIFY -> "Shopify";
+      default -> channel.name();
+    };
   }
 }

--- a/src/main/java/com/conk/order/query/service/SellerProductOptionFetcher.java
+++ b/src/main/java/com/conk/order/query/service/SellerProductOptionFetcher.java
@@ -1,0 +1,14 @@
+package com.conk.order.query.service;
+
+import com.conk.order.query.dto.response.SellerOrderOptionsResponse.ProductOption;
+import java.util.List;
+
+/*
+ * 셀러 주문 등록 옵션용 상품 목록 공급자.
+ *
+ * 현재 order 서비스는 상품 마스터를 직접 보유하지 않으므로 외부 소스(WMS)에서 읽어온다.
+ */
+public interface SellerProductOptionFetcher {
+
+  List<ProductOption> fetchProducts(String sellerId);
+}

--- a/src/main/java/com/conk/order/query/service/WmsSellerProductClient.java
+++ b/src/main/java/com/conk/order/query/service/WmsSellerProductClient.java
@@ -1,0 +1,41 @@
+package com.conk.order.query.service;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+/*
+ * WMS seller 상품 목록 API용 Feign client.
+ */
+@FeignClient(name = "wmsSellerProductClient", url = "${wms.base-url}")
+public interface WmsSellerProductClient {
+
+  @GetMapping("/wms/products/seller/list")
+  WmsApiResponse<List<WmsSellerProductItem>> getSellerProducts(
+      @RequestHeader("X-User-Id") String userId,
+      @RequestHeader("X-Seller-Id") String sellerId,
+      @RequestHeader("X-Tenant-Id") String tenantId
+  );
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  class WmsApiResponse<T> {
+    private boolean success;
+    private String code;
+    private String message;
+    private T data;
+  }
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  class WmsSellerProductItem {
+    private String sku;
+    private String productName;
+  }
+}

--- a/src/main/java/com/conk/order/query/service/WmsSellerProductOptionFetcher.java
+++ b/src/main/java/com/conk/order/query/service/WmsSellerProductOptionFetcher.java
@@ -1,0 +1,63 @@
+package com.conk.order.query.service;
+
+import com.conk.order.common.exception.BusinessException;
+import com.conk.order.common.exception.ErrorCode;
+import com.conk.order.query.dto.response.SellerOrderOptionsResponse.ProductOption;
+import java.util.LinkedHashMap;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/*
+ * WMS seller 상품 목록 API를 Feign으로 호출해 주문 등록용 상품 옵션으로 변환한다.
+ */
+@Component
+public class WmsSellerProductOptionFetcher implements SellerProductOptionFetcher {
+
+  private final WmsSellerProductClient wmsSellerProductClient;
+
+  public WmsSellerProductOptionFetcher(WmsSellerProductClient wmsSellerProductClient) {
+    this.wmsSellerProductClient = wmsSellerProductClient;
+  }
+
+  @Override
+  public List<ProductOption> fetchProducts(String sellerId) {
+    WmsSellerProductClient.WmsApiResponse<List<WmsSellerProductClient.WmsSellerProductItem>> response;
+
+    try {
+      response = wmsSellerProductClient.getSellerProducts(sellerId, sellerId, sellerId);
+    } catch (Exception ex) {
+      throw new BusinessException(ErrorCode.ORDER_OPTIONS_UNAVAILABLE);
+    }
+
+    if (response == null || !response.isSuccess()) {
+      throw new BusinessException(ErrorCode.ORDER_OPTIONS_UNAVAILABLE);
+    }
+
+    List<WmsSellerProductClient.WmsSellerProductItem> products = response.getData();
+    if (products == null || products.isEmpty()) {
+      return List.of();
+    }
+
+    LinkedHashMap<String, ProductOption> deduplicated = new LinkedHashMap<>();
+    for (WmsSellerProductClient.WmsSellerProductItem product : products) {
+      if (product == null) {
+        continue;
+      }
+      String sku = normalizeText(product.getSku());
+      if (sku.isBlank()) {
+        continue;
+      }
+      String productName = normalizeText(product.getProductName());
+      deduplicated.putIfAbsent(
+          sku,
+          new ProductOption(sku, productName.isBlank() ? sku : productName)
+      );
+    }
+
+    return List.copyOf(deduplicated.values());
+  }
+
+  private String normalizeText(Object value) {
+    return value == null ? "" : String.valueOf(value).trim();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,8 @@ order:
   bulk-upload:
     max-row-limit: 5000
     flush-interval: 500
+wms:
+  base-url: ${WMS_SERVICE_URL:http://localhost:8083}
 management:
   endpoints:
     web:
@@ -51,4 +53,3 @@ management:
   endpoint:
     health:
       show-details: always
-

--- a/src/main/resources/mappers/AdminOrderListQueryMapper.xml
+++ b/src/main/resources/mappers/AdminOrderListQueryMapper.xml
@@ -41,7 +41,7 @@
     -->
     <select id="findOrders" resultType="com.conk.order.query.dto.response.AdminOrderSummary">
         SELECT
-            o.order_id           AS orderNo,
+            o.order_id           AS orderId,
             o.ordered_at         AS orderedAt,
             o.status             AS status,
             o.order_channel      AS orderChannel,

--- a/src/main/resources/mappers/SellerOrderListQueryMapper.xml
+++ b/src/main/resources/mappers/SellerOrderListQueryMapper.xml
@@ -38,7 +38,7 @@
 
       resultType = SellerOrderSummary FQCN.
       MyBatis 가 SELECT 컬럼명을 DTO 필드명에 자동 매핑한다.
-        order_no      → orderNo
+        order_id      → orderId
         ordered_at    → orderedAt
         status        → status  (String → OrderStatus 자동 변환)
         order_channel → orderChannel
@@ -47,7 +47,7 @@
     -->
     <select id="findOrders" resultType="com.conk.order.query.dto.response.SellerOrderSummary">
         SELECT
-            o.order_id           AS orderNo,
+            o.order_id           AS orderId,
             o.ordered_at         AS orderedAt,
             o.status             AS status,
             o.order_channel      AS orderChannel,

--- a/src/main/resources/mappers/WhmOrderListQueryMapper.xml
+++ b/src/main/resources/mappers/WhmOrderListQueryMapper.xml
@@ -35,7 +35,7 @@
 
       resultType = WhmOrderSummary FQCN.
       MyBatis 가 SELECT 컬럼명을 DTO 필드명에 자동 매핑한다.
-        order_id      → orderNo
+        order_id      → orderId
         ordered_at    → orderedAt
         status        → status  (String → OrderStatus 자동 변환)
         order_channel → orderChannel
@@ -44,7 +44,7 @@
     -->
     <select id="findOrders" resultType="com.conk.order.query.dto.response.WhmOrderSummary">
         SELECT
-            o.order_id           AS orderNo,
+            o.order_id           AS orderId,
             o.ordered_at         AS orderedAt,
             o.status             AS status,
             o.order_channel      AS orderChannel,

--- a/src/test/java/com/conk/order/query/controller/AdminOrderListQueryControllerTest.java
+++ b/src/test/java/com/conk/order/query/controller/AdminOrderListQueryControllerTest.java
@@ -46,7 +46,7 @@ class AdminOrderListQueryControllerTest {
   @Test
   void getAdminOrders_returnsOkWithData() throws Exception {
     AdminOrderSummary summary = new AdminOrderSummary();
-    summary.setOrderNo("ORD-001");
+    summary.setOrderId("ORD-001");
     summary.setOrderedAt(LocalDateTime.of(2026, 4, 5, 10, 0));
     summary.setStatus(OrderStatus.RECEIVED);
     summary.setOrderChannel(OrderChannel.MANUAL);
@@ -60,7 +60,7 @@ class AdminOrderListQueryControllerTest {
     mockMvc.perform(get("/orders/list"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.success").value(true))
-        .andExpect(jsonPath("$.data.orders[0].orderNo").value("ORD-001"))
+        .andExpect(jsonPath("$.data.orders[0].orderId").value("ORD-001"))
         .andExpect(jsonPath("$.data.orders[0].sellerId").value("SELLER-001"))
         .andExpect(jsonPath("$.data.totalCount").value(1))
         .andExpect(jsonPath("$.data.page").value(0))

--- a/src/test/java/com/conk/order/query/controller/SellerOrderListQueryControllerTest.java
+++ b/src/test/java/com/conk/order/query/controller/SellerOrderListQueryControllerTest.java
@@ -37,7 +37,7 @@ class SellerOrderListQueryControllerTest {
   @Test
   void getSellerOrders_returnsOkWithData() throws Exception {
     SellerOrderSummary summary = new SellerOrderSummary();
-    summary.setOrderNo("ORD-001");
+    summary.setOrderId("ORD-001");
     summary.setOrderedAt(LocalDateTime.of(2026, 4, 3, 10, 0));
     summary.setStatus(OrderStatus.RECEIVED);
     summary.setOrderChannel(OrderChannel.MANUAL);
@@ -51,7 +51,7 @@ class SellerOrderListQueryControllerTest {
             .header("X-User-Id", "SELLER-001"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.success").value(true))
-        .andExpect(jsonPath("$.data.orders[0].orderNo").value("ORD-001"))
+        .andExpect(jsonPath("$.data.orders[0].orderId").value("ORD-001"))
         .andExpect(jsonPath("$.data.orders[0].status").value("RECEIVED"))
         .andExpect(jsonPath("$.data.totalCount").value(1))
         .andExpect(jsonPath("$.data.page").value(0))

--- a/src/test/java/com/conk/order/query/controller/SellerOrderListQueryControllerTest.java
+++ b/src/test/java/com/conk/order/query/controller/SellerOrderListQueryControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.conk.order.command.domain.aggregate.OrderChannel;
 import com.conk.order.command.domain.aggregate.OrderStatus;
 import com.conk.order.query.dto.response.SellerOrderListResponse;
+import com.conk.order.query.dto.response.SellerOrderOptionsResponse;
 import com.conk.order.query.dto.response.SellerOrderSummary;
 import com.conk.order.query.service.SellerOrderQueryService;
 import java.time.LocalDateTime;
@@ -58,12 +59,38 @@ class SellerOrderListQueryControllerTest {
         .andExpect(jsonPath("$.data.size").value(20));
   }
 
+  @Test
+  void getSellerOrderOptions_returnsOkWithData() throws Exception {
+    SellerOrderOptionsResponse response = new SellerOrderOptionsResponse(
+        List.of(new SellerOrderOptionsResponse.ProductOption("SKU-001", "마스크팩 세트")),
+        List.of(new SellerOrderOptionsResponse.ChannelOption("SHOPIFY", "Shopify"))
+    );
+
+    given(sellerOrderQueryService.getOrderOptions("SELLER-001"))
+        .willReturn(response);
+
+    mockMvc.perform(get("/orders/seller/options")
+            .header("X-User-Id", "SELLER-001"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.products[0].sku").value("SKU-001"))
+        .andExpect(jsonPath("$.data.products[0].productName").value("마스크팩 세트"))
+        .andExpect(jsonPath("$.data.channels[0].value").value("SHOPIFY"))
+        .andExpect(jsonPath("$.data.channels[0].label").value("Shopify"));
+  }
+
   /*
    * X-User-Id 헤더가 없으면 GlobalExceptionHandler 가 401 Unauthorized 를 반환한다.
    */
   @Test
   void getSellerOrders_returnsUnauthorized_whenUserIdHeaderMissing() throws Exception {
     mockMvc.perform(get("/orders/seller/list"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void getSellerOrderOptions_returnsUnauthorized_whenUserIdHeaderMissing() throws Exception {
+    mockMvc.perform(get("/orders/seller/options"))
         .andExpect(status().isUnauthorized());
   }
 }

--- a/src/test/java/com/conk/order/query/controller/WhmOrderListQueryControllerTest.java
+++ b/src/test/java/com/conk/order/query/controller/WhmOrderListQueryControllerTest.java
@@ -39,7 +39,7 @@ class WhmOrderListQueryControllerTest {
   @Test
   void getWhmOrders_returnsOkWithData() throws Exception {
     WhmOrderSummary summary = new WhmOrderSummary();
-    summary.setOrderNo("ORD-001");
+    summary.setOrderId("ORD-001");
     summary.setOrderedAt(LocalDateTime.of(2026, 4, 5, 10, 0));
     summary.setStatus(OrderStatus.RECEIVED);
     summary.setOrderChannel(OrderChannel.MANUAL);
@@ -53,7 +53,7 @@ class WhmOrderListQueryControllerTest {
             .param("warehouseId", "WH-001"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.success").value(true))
-        .andExpect(jsonPath("$.data.orders[0].orderNo").value("ORD-001"))
+        .andExpect(jsonPath("$.data.orders[0].orderId").value("ORD-001"))
         .andExpect(jsonPath("$.data.totalCount").value(1))
         .andExpect(jsonPath("$.data.page").value(0))
         .andExpect(jsonPath("$.data.size").value(20));

--- a/src/test/java/com/conk/order/query/service/AdminOrderListQueryServiceTest.java
+++ b/src/test/java/com/conk/order/query/service/AdminOrderListQueryServiceTest.java
@@ -73,9 +73,9 @@ class AdminOrderListQueryServiceTest {
   // ── 헬퍼 ──────────────────────────────────────────────────────────────────
 
   /* 테스트용 주문 요약 객체를 생성한다. */
-  private AdminOrderSummary summary(String orderNo, String sellerId) {
+  private AdminOrderSummary summary(String orderId, String sellerId) {
     AdminOrderSummary s = new AdminOrderSummary();
-    s.setOrderNo(orderNo);
+    s.setOrderId(orderId);
     s.setOrderedAt(LocalDateTime.of(2026, 4, 5, 10, 0));
     s.setStatus(OrderStatus.RECEIVED);
     s.setOrderChannel(OrderChannel.MANUAL);

--- a/src/test/java/com/conk/order/query/service/SellerOrderListQueryServiceTest.java
+++ b/src/test/java/com/conk/order/query/service/SellerOrderListQueryServiceTest.java
@@ -81,9 +81,9 @@ class SellerOrderListQueryServiceTest {
   // ── 헬퍼 ──────────────────────────────────────────────────────────────────
 
   /* 테스트용 주문 요약 객체를 생성한다. */
-  private SellerOrderSummary summary(String orderNo) {
+  private SellerOrderSummary summary(String orderId) {
     SellerOrderSummary s = new SellerOrderSummary();
-    s.setOrderNo(orderNo);
+    s.setOrderId(orderId);
     s.setOrderedAt(LocalDateTime.of(2026, 4, 3, 10, 0));
     s.setStatus(OrderStatus.RECEIVED);
     s.setOrderChannel(OrderChannel.MANUAL);

--- a/src/test/java/com/conk/order/query/service/SellerOrderListQueryServiceTest.java
+++ b/src/test/java/com/conk/order/query/service/SellerOrderListQueryServiceTest.java
@@ -31,7 +31,7 @@ class SellerOrderListQueryServiceTest {
     StubMapper stub = new StubMapper(List.of(
         summary("ORD-001"), summary("ORD-002")
     ), 2);
-    SellerOrderQueryService service = new SellerOrderQueryService(stub, null, null);
+    SellerOrderQueryService service = new SellerOrderQueryService(stub, null, null, sellerId -> List.of());
 
     SellerOrderListQuery query = new SellerOrderListQuery();
     query.setSellerId("SELLER-001");
@@ -46,7 +46,7 @@ class SellerOrderListQueryServiceTest {
   @Test
   void getSellerOrders_returnsEmptyList_whenNoOrders() {
     StubMapper stub = new StubMapper(List.of(), 0);
-    SellerOrderQueryService service = new SellerOrderQueryService(stub, null, null);
+    SellerOrderQueryService service = new SellerOrderQueryService(stub, null, null, sellerId -> List.of());
 
     SellerOrderListQuery query = new SellerOrderListQuery();
     query.setSellerId("SELLER-999");
@@ -65,7 +65,7 @@ class SellerOrderListQueryServiceTest {
      * 프론트에서 "현재 2페이지, 10개씩" 표시에 필요한 값이다.
      */
     StubMapper stub = new StubMapper(List.of(), 0);
-    SellerOrderQueryService service = new SellerOrderQueryService(stub, null, null);
+    SellerOrderQueryService service = new SellerOrderQueryService(stub, null, null, sellerId -> List.of());
 
     SellerOrderListQuery query = new SellerOrderListQuery();
     query.setSellerId("SELLER-001");

--- a/src/test/java/com/conk/order/query/service/SellerOrderOptionsQueryServiceTest.java
+++ b/src/test/java/com/conk/order/query/service/SellerOrderOptionsQueryServiceTest.java
@@ -1,0 +1,40 @@
+package com.conk.order.query.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.conk.order.query.dto.response.SellerOrderOptionsResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/*
+ * 셀러 주문 등록 옵션 조회 서비스 단위 테스트.
+ *
+ * 상품 목록은 외부 fetcher 를 stub 으로 대체하고,
+ * 서비스가 채널 옵션과 함께 응답 DTO 를 올바르게 조립하는지만 검증한다.
+ */
+class SellerOrderOptionsQueryServiceTest {
+
+  @Test
+  void getOrderOptions_returnsProductsAndSelectableChannels() {
+    SellerProductOptionFetcher fetcher = sellerId -> List.of(
+        new SellerOrderOptionsResponse.ProductOption("SKU-001", "마스크팩 세트"),
+        new SellerOrderOptionsResponse.ProductOption("SKU-002", "앰플")
+    );
+    SellerOrderQueryService service = new SellerOrderQueryService(null, null, null, fetcher);
+
+    SellerOrderOptionsResponse response = service.getOrderOptions("SELLER-001");
+
+    assertThat(response.getProducts())
+        .extracting(SellerOrderOptionsResponse.ProductOption::getSku,
+            SellerOrderOptionsResponse.ProductOption::getProductName)
+        .containsExactly(
+            tuple("SKU-001", "마스크팩 세트"),
+            tuple("SKU-002", "앰플")
+        );
+    assertThat(response.getChannels())
+        .extracting(SellerOrderOptionsResponse.ChannelOption::getValue,
+            SellerOrderOptionsResponse.ChannelOption::getLabel)
+        .containsExactly(tuple("SHOPIFY", "Shopify"));
+  }
+}

--- a/src/test/java/com/conk/order/query/service/WhmOrderListQueryServiceTest.java
+++ b/src/test/java/com/conk/order/query/service/WhmOrderListQueryServiceTest.java
@@ -73,9 +73,9 @@ class WhmOrderListQueryServiceTest {
 
   // ── 헬퍼 ──────────────────────────────────────────────────────────────────
 
-  private WhmOrderSummary summary(String orderNo) {
+  private WhmOrderSummary summary(String orderId) {
     WhmOrderSummary s = new WhmOrderSummary();
-    s.setOrderNo(orderNo);
+    s.setOrderId(orderId);
     s.setOrderedAt(LocalDateTime.of(2026, 4, 5, 10, 0));
     s.setStatus(OrderStatus.RECEIVED);
     s.setOrderChannel(OrderChannel.MANUAL);

--- a/src/test/java/com/conk/order/query/service/WmsSellerProductOptionFetcherTest.java
+++ b/src/test/java/com/conk/order/query/service/WmsSellerProductOptionFetcherTest.java
@@ -1,0 +1,48 @@
+package com.conk.order.query.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.conk.order.query.dto.response.SellerOrderOptionsResponse.ProductOption;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/*
+ * WMS 상품 옵션 fetcher 단위 테스트.
+ *
+ * Feign client 를 Mockito 로 대체하고, 응답 매핑과 헤더 전달만 검증한다.
+ */
+class WmsSellerProductOptionFetcherTest {
+
+  @Test
+  void fetchProducts_mapsWmsProductListResponse() {
+    WmsSellerProductClient client = mock(WmsSellerProductClient.class);
+    WmsSellerProductClient.WmsSellerProductItem item1 = new WmsSellerProductClient.WmsSellerProductItem();
+    item1.setSku("SKU-001");
+    item1.setProductName("마스크팩 세트");
+    WmsSellerProductClient.WmsSellerProductItem item2 = new WmsSellerProductClient.WmsSellerProductItem();
+    item2.setSku("SKU-002");
+    item2.setProductName("앰플");
+    WmsSellerProductClient.WmsApiResponse<List<WmsSellerProductClient.WmsSellerProductItem>> response =
+        new WmsSellerProductClient.WmsApiResponse<>();
+    response.setSuccess(true);
+    response.setData(List.of(item1, item2));
+
+    given(client.getSellerProducts("SELLER-001", "SELLER-001", "SELLER-001"))
+        .willReturn(response);
+
+    WmsSellerProductOptionFetcher fetcher = new WmsSellerProductOptionFetcher(client);
+
+    List<ProductOption> result = fetcher.fetchProducts("SELLER-001");
+
+    assertThat(result)
+        .extracting(ProductOption::getSku, ProductOption::getProductName)
+        .containsExactly(
+            org.assertj.core.groups.Tuple.tuple("SKU-001", "마스크팩 세트"),
+            org.assertj.core.groups.Tuple.tuple("SKU-002", "앰플")
+        );
+    verify(client).getSellerProducts("SELLER-001", "SELLER-001", "SELLER-001");
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,3 +31,6 @@ order:
   bulk-upload:
     max-row-limit: 5000
     flush-interval: 500
+
+wms:
+  base-url: http://localhost:8083


### PR DESCRIPTION
## 📝 작업 내용
- 셀러/총괄/창고 주문 응답 계약의 식별자를 `orderId` 기준으로 정렬했습니다.
- 셀러 주문 등록 화면용 `GET /orders/seller/options` 엔드포인트를 추가했습니다.
- WMS seller 상품 목록 조회를 OpenFeign 기반 내부통신으로 연결했습니다.
- 관련 컨트롤러/서비스/테스트를 함께 정리했습니다.

## 📂 관련 파일 (Scope)
- `src/main/java/com/conk/order/query/controller/SellerOrderQueryController.java`
- `src/main/java/com/conk/order/query/service/SellerOrderQueryService.java`
- `src/main/java/com/conk/order/query/service/WmsSellerProductClient.java`
- `src/main/java/com/conk/order/query/service/WmsSellerProductOptionFetcher.java`
- `src/main/java/com/conk/order/query/dto/response/SellerOrderOptionsResponse.java`
- `src/test/java/com/conk/order/query/controller/SellerOrderListQueryControllerTest.java`
- `src/test/java/com/conk/order/query/service/SellerOrderOptionsQueryServiceTest.java`
- `src/test/java/com/conk/order/query/service/WmsSellerProductOptionFetcherTest.java`

## 🎯 관련 이슈
- 없음

## ⚠️ 유의사항 및 특이사항
- PR 대상 브랜치는 `main`입니다.
- 루트 저장소의 `docker-compose.yml` 변경은 이번 backend PR에 포함하지 않았습니다.
- 로컬 설정 파일 `.claude/settings.local.json` 변경은 제외했습니다.
- 셀러/총괄/창고 목록성 응답에서 `orderNo` 대신 `orderId`를 반환합니다.

## ✅ 체크리스트
- [x] 커밋 내역이 정리되어 있는가?
- [x] 불필요한 파일이 없는가?
